### PR TITLE
Refactor group and session scope across shell and creation flows

### DIFF
--- a/app/[locale]/groups/[groupId]/page.tsx
+++ b/app/[locale]/groups/[groupId]/page.tsx
@@ -135,6 +135,7 @@ export default async function GroupRoutePage({
             const groupSchedules = (schedules ?? []).filter((schedule) => schedule.group_id === group.id);
             const firstSchedule = groupSchedules[0];
             const weeklyQuestions = groupSchedules.reduce((sum, schedule) => sum + (schedule.question_goal ?? 0), 0);
+            const groupMemberships = (membershipsWithUsers ?? []).filter((membership) => membership.group_id === group.id);
             const membersPreview = (membershipsWithUsers ?? [])
               .filter((membership) => membership.group_id === group.id)
               .slice(0, 4)
@@ -152,6 +153,7 @@ export default async function GroupRoutePage({
               id: group.id,
               name: group.name,
               language: locale.toUpperCase(),
+              memberCount: groupMemberships.length,
               scheduleLabel: firstSchedule
                 ? `${firstSchedule.start_time?.slice(0, 5) ?? '--:--'} - ${firstSchedule.end_time?.slice(0, 5) ?? '--:--'}`
                 : '',

--- a/app/[locale]/groups/[groupId]/page.tsx
+++ b/app/[locale]/groups/[groupId]/page.tsx
@@ -72,6 +72,7 @@ export default async function GroupRoutePage({
 
   const examSession =
     currentProfile?.exam_session ?? (typeof user.user_metadata.exam_session === 'string' ? user.user_metadata.exam_session : '');
+  const displayName = user.user_metadata.full_name ?? user.email ?? 'ActiveBoard';
   const examSessionLabel =
     examSession === 'april_may_2026'
       ? t('examAprilMay2026')
@@ -97,6 +98,69 @@ export default async function GroupRoutePage({
   };
 
   const currentGroupIds = new Set(memberships.map((membership) => membership.group_id));
+  const shellGroups =
+    memberships.length > 0
+      ? await (async () => {
+          const supabase = createSupabaseServerClient();
+          const supabaseAdmin = createSupabaseAdminClient();
+          const groupIds = [...new Set(memberships.map((membership) => membership.group_id))];
+          const [{ data: groups }, { data: schedules }, { data: membershipsWithUsers }] = await Promise.all([
+            supabase
+              .schema('public')
+              .from('groups')
+              .select('id, name')
+              .in('id', groupIds)
+              .order('created_at', { ascending: false }),
+            supabase
+              .schema('public')
+              .from('group_weekly_schedules')
+              .select('group_id, start_time, end_time, question_goal')
+              .in('group_id', groupIds),
+            supabaseAdmin.schema('public').from('group_members').select('group_id, user_id').in('group_id', groupIds),
+          ]);
+
+          const memberIds = [...new Set((membershipsWithUsers ?? []).map((membership) => membership.user_id))];
+          const { data: memberProfiles } =
+            memberIds.length > 0
+              ? await supabaseAdmin
+                  .schema('public')
+                  .from('users')
+                  .select('id, display_name, email, avatar_url')
+                  .in('id', memberIds)
+              : { data: [] };
+
+          const memberProfileById = new Map((memberProfiles ?? []).map((profile) => [profile.id, profile]));
+
+          return (groups ?? []).map((group) => {
+            const groupSchedules = (schedules ?? []).filter((schedule) => schedule.group_id === group.id);
+            const firstSchedule = groupSchedules[0];
+            const weeklyQuestions = groupSchedules.reduce((sum, schedule) => sum + (schedule.question_goal ?? 0), 0);
+            const membersPreview = (membershipsWithUsers ?? [])
+              .filter((membership) => membership.group_id === group.id)
+              .slice(0, 4)
+              .map((membership) => {
+                const profile = memberProfileById.get(membership.user_id);
+                const displayLabel = profile?.display_name ?? profile?.email ?? 'AB';
+                return {
+                  id: membership.user_id,
+                  initials: getInitials(displayLabel),
+                  avatarUrl: profile?.avatar_url ?? null,
+                };
+              });
+
+            return {
+              id: group.id,
+              name: group.name,
+              language: locale.toUpperCase(),
+              scheduleLabel: firstSchedule
+                ? `${firstSchedule.start_time?.slice(0, 5) ?? '--:--'} - ${firstSchedule.end_time?.slice(0, 5) ?? '--:--'}`
+                : '',
+              weeklyQuestions,
+              membersPreview,
+            };
+          });
+        })()
+      : [];
   const liveGroups =
     canBrowseLookupLayer && primaryGroup
       ? await (async () => {
@@ -187,6 +251,8 @@ export default async function GroupRoutePage({
       <section className="mx-auto w-full max-w-[620px] space-y-4">
         <GroupPageView
           locale={locale}
+          shellGroups={shellGroups}
+          currentUserInitials={getInitials(displayName)}
           canBrowseLookupLayer={canBrowseLookupLayer}
           initialLiveOpen={searchParams.live === '1'}
           primaryGroup={primaryGroup}
@@ -202,6 +268,10 @@ export default async function GroupRoutePage({
           canCreateSession={canCreateSession}
           liveGroups={liveGroups}
           labels={{
+            myGroups: t('myGroups'),
+            activeGroup: t('activeGroup'),
+            selectGroupHint: t('selectGroupHint'),
+            noSchedule: t('noSchedule'),
             newSession: t('newSession'),
             createSession: t('createSession'),
             createSessionPending: t('createSessionPending'),

--- a/app/[locale]/groups/[groupId]/page.tsx
+++ b/app/[locale]/groups/[groupId]/page.tsx
@@ -344,6 +344,7 @@ export default async function GroupRoutePage({
             memberCompletion: t('memberCompletion', { value: '{value}' }),
             memberTotal: t('memberTotal', { value: '{value}' }),
             captainLabel: t('captainLabel'),
+            memberStatusSetup: t('memberStatusSetup'),
             memberStatusActive: t('memberStatusActive'),
             groupViewEmpty: t('groupViewEmpty'),
             groupAccessHint: t('groupAccessHint'),

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -176,7 +176,7 @@ export default async function LocaleLayout({
         <div className="mx-auto flex min-h-[calc(100vh-2rem)] max-w-[1240px] flex-col gap-4 sm:gap-5">
           <OfflineStatusBanner />
           <header className="border-b border-[#1f2937]/80 pb-3 pt-1">
-            <div className="flex min-w-0 flex-wrap items-center justify-between gap-3 sm:flex-nowrap sm:gap-4">
+            <div className="flex min-w-0 items-start justify-between gap-3 sm:items-center sm:gap-4">
             <div className="flex min-w-0 flex-1 items-center gap-2">
               <Link href="/" className="flex min-w-0 shrink-0 items-center gap-2">
                 <div className="flex h-7 w-7 items-center justify-center rounded-[5px] bg-brand text-xs font-extrabold text-white">
@@ -186,7 +186,7 @@ export default async function LocaleLayout({
               </Link>
             </div>
 
-            <div className="flex min-w-0 w-full items-center justify-between gap-2 sm:w-auto sm:shrink-0 sm:justify-end sm:gap-3">
+            <div className="flex min-w-0 shrink-0 items-center justify-end gap-2 sm:gap-3">
               {user ? (
                 <>
                   <Suspense
@@ -222,7 +222,7 @@ export default async function LocaleLayout({
                   />
                 </>
               ) : (
-                <div className="flex w-full items-center justify-between gap-2 sm:w-auto sm:justify-end sm:gap-3">
+                <div className="flex shrink-0 items-center gap-3">
                   <Suspense
                     fallback={
                       <div className="inline-flex items-center gap-2 rounded-full border border-border bg-white/[0.04] px-4 py-2 text-sm text-slate-400">
@@ -232,11 +232,15 @@ export default async function LocaleLayout({
                   >
                     <LanguageSwitcher />
                   </Suspense>
-                  <HomeHeaderNav />
                 </div>
               )}
             </div>
             </div>
+            {!user ? (
+              <div className="mt-3">
+                <HomeHeaderNav />
+              </div>
+            ) : null}
           </header>
           {children}
         </div>

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -120,6 +120,15 @@ export default async function LocaleLayout({
             <div className="flex min-w-0 shrink-0 items-center justify-end gap-2 sm:gap-3">
               {user ? (
                 <>
+                  <Suspense
+                    fallback={
+                      <div className="inline-flex items-center gap-2 rounded-full border border-border bg-white/[0.04] px-4 py-2 text-sm text-slate-400">
+                        {t('language')}
+                      </div>
+                    }
+                  >
+                    <LanguageSwitcher />
+                  </Suspense>
                   <Link
                     href={shellData.canBrowseLookupLayer ? '/groups?live=1' : '/billing'}
                     className="inline-flex h-10 items-center gap-1.5 rounded-[8px] bg-amber-500/10 px-3 text-xs font-extrabold text-amber-400 ring-1 ring-amber-500/10 transition hover:bg-amber-500/15"
@@ -133,14 +142,12 @@ export default async function LocaleLayout({
                     name={displayName}
                     email={user.email ?? ''}
                     isCaptain={shellData.isCaptain}
-                    locale={locale}
                     profileHref="/profile"
                     profileLabel={profileT('menuLabel')}
                     examHref="/profile?section=exam"
                     examLabel={profileT('examSettingsMenuLabel')}
                     billingHref="/billing"
                     billingLabel={billingT('menuLabel')}
-                    languageLabel={locale === 'fr' ? t('english') : t('french')}
                   />
                 </>
               ) : (

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, getTranslations, setRequestLocale } from 'next-intl/server';
+import { Lock } from 'lucide-react';
 
 import { AppBottomNav } from '@/components/layout/app-bottom-nav';
 import { HomeHeaderNav } from '@/components/layout/home-header-nav';
@@ -12,6 +13,8 @@ import { RegisterServiceWorker } from '@/components/pwa/register-service-worker'
 import { Link } from '@/i18n/navigation';
 import { routing, type AppLocale } from '@/i18n/routing';
 import { getCurrentUser } from '@/lib/auth';
+import { getUserAccessState, hasUserTierCapability } from '@/lib/billing/gating';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 export function generateStaticParams() {
@@ -34,12 +37,40 @@ export default async function LocaleLayout({
   setRequestLocale(locale);
   const messages = await getMessages();
   const t = await getTranslations('Common');
+  const dashboardT = await getTranslations('Dashboard');
   const billingT = await getTranslations('Billing');
   const profileT = await getTranslations('Profile');
   const user = await getCurrentUser();
   const shellData = user
       ? await (async () => {
         const supabase = createSupabaseServerClient();
+        const supabaseAdmin = createSupabaseAdminClient();
+        const accessState = await getUserAccessState(user.id);
+        const canBrowseLookupLayer = hasUserTierCapability(accessState, 'canBrowseLookupLayer');
+        const { data: memberships } = await supabase
+          .schema('public')
+          .from('group_members')
+          .select('group_id')
+          .eq('user_id', user.id);
+        const groupIds = [...new Set((memberships ?? []).map((membership) => membership.group_id))];
+        const { data: candidateGroups } = await supabaseAdmin
+          .schema('public')
+          .from('groups')
+          .select('id, max_members')
+          .order('created_at', { ascending: false })
+          .limit(30);
+        const candidateGroupIds = (candidateGroups ?? []).map((group) => group.id);
+        const { data: candidateMemberships } =
+          candidateGroupIds.length > 0
+            ? await supabaseAdmin.schema('public').from('group_members').select('group_id').in('group_id', candidateGroupIds)
+            : { data: [] };
+        const candidateCounts = new Map<string, number>();
+        for (const membership of candidateMemberships ?? []) {
+          candidateCounts.set(membership.group_id, (candidateCounts.get(membership.group_id) ?? 0) + 1);
+        }
+        const liveGroupCount = (candidateGroups ?? []).filter(
+          (group) => !groupIds.includes(group.id) && (candidateCounts.get(group.id) ?? 0) < (group.max_members ?? 5),
+        ).length;
         const { data: captainSession } = await supabase
           .schema('public')
           .from('sessions')
@@ -50,9 +81,11 @@ export default async function LocaleLayout({
           .maybeSingle();
         return {
           isCaptain: Boolean(captainSession),
+          liveGroupCount,
+          canBrowseLookupLayer,
         };
       })()
-    : { isCaptain: false };
+    : { isCaptain: false, liveGroupCount: 0, canBrowseLookupLayer: false };
   const displayName = user?.user_metadata.full_name ?? user?.email ?? 'ActiveBoard';
   const initials =
     displayName
@@ -87,6 +120,14 @@ export default async function LocaleLayout({
             <div className="flex min-w-0 shrink-0 items-center justify-end gap-2 sm:gap-3">
               {user ? (
                 <>
+                  <Link
+                    href={shellData.canBrowseLookupLayer ? '/groups?live=1' : '/billing'}
+                    className="inline-flex h-10 items-center gap-1.5 rounded-[8px] bg-amber-500/10 px-3 text-xs font-extrabold text-amber-400 ring-1 ring-amber-500/10 transition hover:bg-amber-500/15"
+                    aria-label={`${dashboardT('joinLiveGroups')} ${shellData.liveGroupCount}`}
+                  >
+                    <Lock className="h-3.5 w-3.5" aria-hidden="true" strokeWidth={1.8} />
+                    {shellData.liveGroupCount}
+                  </Link>
                   <ProfileMenu
                     initials={initials}
                     name={displayName}

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -4,7 +4,6 @@ import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { AppBottomNav } from '@/components/layout/app-bottom-nav';
-import { GroupSwitcherMenu } from '@/components/layout/group-switcher-menu';
 import { HomeHeaderNav } from '@/components/layout/home-header-nav';
 import { LanguageSwitcher } from '@/components/layout/language-switcher';
 import { ProfileMenu } from '@/components/layout/profile-menu';
@@ -13,8 +12,6 @@ import { RegisterServiceWorker } from '@/components/pwa/register-service-worker'
 import { Link } from '@/i18n/navigation';
 import { routing, type AppLocale } from '@/i18n/routing';
 import { getCurrentUser } from '@/lib/auth';
-import { getUserAccessState, hasUserTierCapability } from '@/lib/billing/gating';
-import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 export function generateStaticParams() {
@@ -37,104 +34,12 @@ export default async function LocaleLayout({
   setRequestLocale(locale);
   const messages = await getMessages();
   const t = await getTranslations('Common');
-  const dashboardT = await getTranslations('Dashboard');
   const billingT = await getTranslations('Billing');
   const profileT = await getTranslations('Profile');
   const user = await getCurrentUser();
   const shellData = user
       ? await (async () => {
         const supabase = createSupabaseServerClient();
-        const supabaseAdmin = createSupabaseAdminClient();
-        const accessState = await getUserAccessState(user.id);
-        const canBrowseLookupLayer = hasUserTierCapability(accessState, 'canBrowseLookupLayer');
-        const { data: memberships } = await supabase
-          .schema('public')
-          .from('group_members')
-          .select('group_id')
-          .eq('user_id', user.id);
-        const groupIds = [...new Set((memberships ?? []).map((membership) => membership.group_id))];
-        const { data: candidateGroups } = await supabaseAdmin
-          .schema('public')
-          .from('groups')
-          .select('id, max_members')
-          .order('created_at', { ascending: false })
-          .limit(30);
-        const candidateGroupIds = (candidateGroups ?? []).map((group) => group.id);
-        const { data: candidateMemberships } =
-          candidateGroupIds.length > 0
-            ? await supabaseAdmin.schema('public').from('group_members').select('group_id').in('group_id', candidateGroupIds)
-            : { data: [] };
-        const candidateCounts = new Map<string, number>();
-        for (const membership of candidateMemberships ?? []) {
-          candidateCounts.set(membership.group_id, (candidateCounts.get(membership.group_id) ?? 0) + 1);
-        }
-        const liveGroupCount = (candidateGroups ?? []).filter(
-          (group) => !groupIds.includes(group.id) && (candidateCounts.get(group.id) ?? 0) < (group.max_members ?? 5),
-        ).length;
-        if (groupIds.length === 0) return { groups: [], isCaptain: false, liveGroupCount, canBrowseLookupLayer };
-        const { data: groups } = await supabase
-          .schema('public')
-          .from('groups')
-          .select('id, name')
-          .in('id', groupIds)
-          .order('created_at', { ascending: false });
-        const { data: schedules } = await supabase
-          .schema('public')
-          .from('group_weekly_schedules')
-          .select('group_id, weekday, start_time, end_time, question_goal')
-          .in('group_id', groupIds)
-          .order('weekday', { ascending: true });
-        const { data: membershipsWithUsers } = await supabaseAdmin
-          .schema('public')
-          .from('group_members')
-          .select('group_id, user_id')
-          .in('group_id', groupIds);
-        const memberIds = [...new Set((membershipsWithUsers ?? []).map((membership) => membership.user_id))];
-        const { data: memberProfiles } =
-          memberIds.length > 0
-            ? await supabaseAdmin
-                .schema('public')
-                .from('users')
-                .select('id, display_name, email, avatar_url')
-                .in('id', memberIds)
-            : { data: [] };
-        const scheduleByGroup = new Map<string, { scheduleLabel: string; weeklyQuestions: number }>();
-        const memberProfileById = new Map((memberProfiles ?? []).map((profile) => [profile.id, profile]));
-        const membersPreviewByGroup = new Map<
-          string,
-          Array<{ id: string; initials: string; avatarUrl: string | null }>
-        >();
-        for (const groupId of groupIds) {
-          const groupSchedules = (schedules ?? []).filter((schedule) => schedule.group_id === groupId);
-          const weeklyQuestions = groupSchedules.reduce((sum, schedule) => sum + (schedule.question_goal ?? 0), 0);
-          const firstSchedule = groupSchedules[0];
-          scheduleByGroup.set(groupId, {
-            scheduleLabel: firstSchedule
-              ? `${firstSchedule.start_time?.slice(0, 5) ?? '--:--'} - ${firstSchedule.end_time?.slice(0, 5) ?? '--:--'}`
-              : '',
-            weeklyQuestions,
-          });
-
-          const memberPreview = (membershipsWithUsers ?? [])
-            .filter((membership) => membership.group_id === groupId)
-            .slice(0, 4)
-            .map((membership) => {
-              const profile = memberProfileById.get(membership.user_id);
-              const displayLabel = profile?.display_name ?? profile?.email ?? 'AB';
-              return {
-                id: membership.user_id,
-                initials: displayLabel
-                  .split(' ')
-                  .filter(Boolean)
-                  .map((part) => part[0])
-                  .join('')
-                  .slice(0, 2)
-                  .toUpperCase(),
-                avatarUrl: profile?.avatar_url ?? null,
-              };
-            });
-          membersPreviewByGroup.set(groupId, memberPreview);
-        }
         const { data: captainSession } = await supabase
           .schema('public')
           .from('sessions')
@@ -144,22 +49,10 @@ export default async function LocaleLayout({
           .limit(1)
           .maybeSingle();
         return {
-          groups: (groups ?? []).map((group) => {
-            const scheduleMeta = scheduleByGroup.get(group.id);
-            return {
-              ...group,
-              language: locale.toUpperCase(),
-              scheduleLabel: scheduleMeta?.scheduleLabel ?? '',
-              weeklyQuestions: scheduleMeta?.weeklyQuestions ?? 0,
-              membersPreview: membersPreviewByGroup.get(group.id) ?? [],
-            };
-          }),
           isCaptain: Boolean(captainSession),
-          liveGroupCount,
-          canBrowseLookupLayer,
         };
       })()
-    : { groups: [], isCaptain: false, liveGroupCount: 0, canBrowseLookupLayer: false };
+    : { isCaptain: false };
   const displayName = user?.user_metadata.full_name ?? user?.email ?? 'ActiveBoard';
   const initials =
     displayName
@@ -175,7 +68,7 @@ export default async function LocaleLayout({
       <div className="min-h-screen overflow-x-hidden px-2 pb-24 pt-2 sm:px-6 sm:pt-4">
         <div className="mx-auto flex min-h-[calc(100vh-2rem)] max-w-[1240px] flex-col gap-4 sm:gap-5">
           <OfflineStatusBanner />
-          <header className="border-b border-[#1f2937]/80 pb-3 pt-1">
+          <header className="border-b border-[#1f2937]/80 pb-2 pt-1">
             <div className="flex min-w-0 items-start justify-between gap-3 sm:items-center sm:gap-4">
             <div className="flex min-w-0 flex-1 items-center gap-2 sm:gap-4">
               <Link href="/" className="flex min-w-0 shrink-0 items-center gap-2">
@@ -185,7 +78,7 @@ export default async function LocaleLayout({
                 <p className="truncate text-base font-extrabold tracking-tight text-white sm:text-lg">{t('appName')}</p>
               </Link>
               {!user ? (
-                <div className="hidden min-w-0 flex-1 items-center sm:flex">
+                <div className="hidden min-w-0 flex-1 items-center justify-end sm:flex">
                   <HomeHeaderNav />
                 </div>
               ) : null}
@@ -194,23 +87,6 @@ export default async function LocaleLayout({
             <div className="flex min-w-0 shrink-0 items-center justify-end gap-2 sm:gap-3">
               {user ? (
                 <>
-                  <Suspense
-                    fallback={null}
-                  >
-                    <GroupSwitcherMenu
-                      groups={shellData.groups}
-                      liveGroupCount={shellData.liveGroupCount}
-                      liveHref={shellData.canBrowseLookupLayer ? '/groups?live=1' : '/billing'}
-                      userInitials={initials}
-                      labels={{
-                        myGroups: dashboardT('myGroups'),
-                        active: dashboardT('activeGroup'),
-                        selectHint: dashboardT('selectGroupHint'),
-                        noSchedule: dashboardT('noSchedule'),
-                        averageWeekly: dashboardT('averageWeeklyShort'),
-                      }}
-                    />
-                  </Suspense>
                   <ProfileMenu
                     initials={initials}
                     name={displayName}
@@ -242,7 +118,7 @@ export default async function LocaleLayout({
             </div>
             </div>
             {!user ? (
-              <div className="mt-3 sm:hidden">
+              <div className="mt-2.5 sm:hidden">
                 <HomeHeaderNav />
               </div>
             ) : null}

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -177,13 +177,18 @@ export default async function LocaleLayout({
           <OfflineStatusBanner />
           <header className="border-b border-[#1f2937]/80 pb-3 pt-1">
             <div className="flex min-w-0 items-start justify-between gap-3 sm:items-center sm:gap-4">
-            <div className="flex min-w-0 flex-1 items-center gap-2">
+            <div className="flex min-w-0 flex-1 items-center gap-2 sm:gap-4">
               <Link href="/" className="flex min-w-0 shrink-0 items-center gap-2">
                 <div className="flex h-7 w-7 items-center justify-center rounded-[5px] bg-brand text-xs font-extrabold text-white">
                   AB
                 </div>
                 <p className="truncate text-base font-extrabold tracking-tight text-white sm:text-lg">{t('appName')}</p>
               </Link>
+              {!user ? (
+                <div className="hidden min-w-0 flex-1 items-center sm:flex">
+                  <HomeHeaderNav />
+                </div>
+              ) : null}
             </div>
 
             <div className="flex min-w-0 shrink-0 items-center justify-end gap-2 sm:gap-3">
@@ -237,7 +242,7 @@ export default async function LocaleLayout({
             </div>
             </div>
             {!user ? (
-              <div className="mt-3">
+              <div className="mt-3 sm:hidden">
                 <HomeHeaderNav />
               </div>
             ) : null}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -58,16 +58,16 @@ export default async function LocaleHomePage({ params }: LocaleHomePageProps) {
 
   return (
     <main className="-mx-3 flex flex-1 flex-col sm:-mx-6">
-      <section className="grid min-h-[unset] items-center gap-6 px-4 pb-10 pt-6 sm:min-h-[660px] sm:gap-10 sm:px-6 sm:pb-16 sm:pt-14 lg:grid-cols-[1fr_0.96fr] lg:px-10">
+      <section className="grid min-h-[unset] items-center gap-5 px-4 pb-10 pt-5 sm:min-h-[620px] sm:gap-8 sm:px-6 sm:pb-14 sm:pt-10 lg:grid-cols-[1fr_0.96fr] lg:px-10">
         <div>
           <p className="inline-flex rounded-full border border-white/[0.08] px-4 py-2 text-sm font-semibold text-slate-400">
             {t('heroEyebrow')}
           </p>
-          <h1 className="mt-6 max-w-[640px] text-[44px] font-medium leading-[0.98] tracking-[-0.052em] text-white sm:mt-8 sm:text-[68px] lg:text-[76px]">
+          <h1 className="mt-5 max-w-[640px] text-[44px] font-medium leading-[0.98] tracking-[-0.052em] text-white sm:mt-7 sm:text-[68px] lg:text-[76px]">
             {t('heroTitle')}
           </h1>
-          <p className="mt-5 max-w-[650px] text-base font-medium leading-7 text-slate-400 sm:mt-7 sm:text-lg sm:leading-8">{t('heroDescription')}</p>
-          <div className="mt-6 flex flex-wrap gap-x-6 gap-y-2.5 text-base font-semibold text-slate-300 sm:mt-8 sm:gap-x-7 sm:gap-y-3">
+          <p className="mt-4 max-w-[650px] text-base font-medium leading-7 text-slate-400 sm:mt-6 sm:text-lg sm:leading-8">{t('heroDescription')}</p>
+          <div className="mt-5 flex flex-wrap gap-x-6 gap-y-2.5 text-base font-semibold text-slate-300 sm:mt-7 sm:gap-x-7 sm:gap-y-3">
             {[t('heroProof1'), t('heroProof2'), t('heroProof3')].map((proof) => (
               <span key={proof} className="inline-flex items-center gap-2">
                 <Check className="h-4 w-4 text-brand" aria-hidden="true" />
@@ -75,7 +75,7 @@ export default async function LocaleHomePage({ params }: LocaleHomePageProps) {
               </span>
             ))}
           </div>
-          <LandingSignupModal locale={locale} closeLabel={t('close')} className="mt-6 inline-flex rounded-[7px] bg-brand px-5 py-4 text-base font-bold text-white shadow-[0_20px_50px_rgba(16,185,129,0.22)] transition hover:bg-brand-strong sm:mt-8">
+          <LandingSignupModal locale={locale} closeLabel={t('close')} className="mt-5 inline-flex rounded-[7px] bg-brand px-5 py-4 text-base font-bold text-white shadow-[0_20px_50px_rgba(16,185,129,0.22)] transition hover:bg-brand-strong sm:mt-7">
             {t('primaryCta')}
           </LandingSignupModal>
           <p className="mt-3 text-sm font-medium text-slate-500 sm:mt-4">{t('noCreditCard')}</p>

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -58,16 +58,16 @@ export default async function LocaleHomePage({ params }: LocaleHomePageProps) {
 
   return (
     <main className="-mx-3 flex flex-1 flex-col sm:-mx-6">
-      <section className="grid min-h-[unset] items-center gap-5 px-4 pb-10 pt-5 sm:min-h-[620px] sm:gap-8 sm:px-6 sm:pb-14 sm:pt-10 lg:grid-cols-[1fr_0.96fr] lg:px-10">
+      <section className="grid min-h-[unset] items-center gap-4 px-4 pb-10 pt-4 sm:min-h-[590px] sm:gap-7 sm:px-6 sm:pb-14 sm:pt-7 lg:grid-cols-[1fr_0.96fr] lg:px-10">
         <div>
           <p className="inline-flex rounded-full border border-white/[0.08] px-4 py-2 text-sm font-semibold text-slate-400">
             {t('heroEyebrow')}
           </p>
-          <h1 className="mt-5 max-w-[640px] text-[44px] font-medium leading-[0.98] tracking-[-0.052em] text-white sm:mt-7 sm:text-[68px] lg:text-[76px]">
+          <h1 className="mt-4 max-w-[640px] text-[44px] font-medium leading-[0.98] tracking-[-0.052em] text-white sm:mt-6 sm:text-[68px] lg:text-[76px]">
             {t('heroTitle')}
           </h1>
-          <p className="mt-4 max-w-[650px] text-base font-medium leading-7 text-slate-400 sm:mt-6 sm:text-lg sm:leading-8">{t('heroDescription')}</p>
-          <div className="mt-5 flex flex-wrap gap-x-6 gap-y-2.5 text-base font-semibold text-slate-300 sm:mt-7 sm:gap-x-7 sm:gap-y-3">
+          <p className="mt-3 max-w-[650px] text-base font-medium leading-7 text-slate-400 sm:mt-5 sm:text-lg sm:leading-8">{t('heroDescription')}</p>
+          <div className="mt-4 flex flex-wrap gap-x-6 gap-y-2.5 text-base font-semibold text-slate-300 sm:mt-6 sm:gap-x-7 sm:gap-y-3">
             {[t('heroProof1'), t('heroProof2'), t('heroProof3')].map((proof) => (
               <span key={proof} className="inline-flex items-center gap-2">
                 <Check className="h-4 w-4 text-brand" aria-hidden="true" />
@@ -75,7 +75,7 @@ export default async function LocaleHomePage({ params }: LocaleHomePageProps) {
               </span>
             ))}
           </div>
-          <LandingSignupModal locale={locale} closeLabel={t('close')} className="mt-5 inline-flex rounded-[7px] bg-brand px-5 py-4 text-base font-bold text-white shadow-[0_20px_50px_rgba(16,185,129,0.22)] transition hover:bg-brand-strong sm:mt-7">
+          <LandingSignupModal locale={locale} closeLabel={t('close')} className="mt-4 inline-flex rounded-[7px] bg-brand px-5 py-4 text-base font-bold text-white shadow-[0_20px_50px_rgba(16,185,129,0.22)] transition hover:bg-brand-strong sm:mt-6">
             {t('primaryCta')}
           </LandingSignupModal>
           <p className="mt-3 text-sm font-medium text-slate-500 sm:mt-4">{t('noCreditCard')}</p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -83,7 +83,7 @@ select optgroup {
   }
 
   .field-compact {
-    @apply h-12 rounded-[16px] border border-border bg-white/[0.06] px-4 text-[15px] font-medium text-white outline-none transition placeholder:text-slate-500 focus:border-brand focus:ring-2 focus:ring-emerald-400/20;
+    @apply h-12 w-full min-w-0 rounded-[16px] border border-border bg-white/[0.06] px-4 text-[15px] font-medium text-white outline-none transition placeholder:text-slate-500 focus:border-brand focus:ring-2 focus:ring-emerald-400/20;
   }
 
   .button-primary {

--- a/components/dashboard/dashboard-sessions-view.tsx
+++ b/components/dashboard/dashboard-sessions-view.tsx
@@ -137,7 +137,7 @@ export function DashboardSessionsView({
 
       {sessions.length > 0 ? (
         <>
-          <form action={joinSessionAction} className="flex flex-col gap-2 sm:flex-row sm:justify-center">
+          <form action={joinSessionAction} className="flex items-center gap-2 sm:justify-center">
             <input type="hidden" name="locale" value={locale} />
             <input
               name="sessionCode"
@@ -145,9 +145,9 @@ export function DashboardSessionsView({
               placeholder={labels.sessionCodePlaceholder}
               autoCapitalize="characters"
               autoComplete="off"
-              className="field h-10 w-full rounded-[7px] px-4 py-2 text-center text-xs uppercase tracking-[0.18em] sm:h-9 sm:max-w-[210px]"
+              className="field h-10 min-w-0 flex-1 rounded-[7px] px-4 py-2 text-center text-xs uppercase tracking-[0.18em] sm:h-9 sm:max-w-[210px] sm:flex-none"
             />
-            <SubmitButton pendingLabel={labels.goPending} className="button-primary h-10 rounded-[7px] px-4 py-2 text-xs sm:h-9" disabled={!canJoinSessions}>
+            <SubmitButton pendingLabel={labels.goPending} className="button-primary h-10 w-[96px] shrink-0 rounded-[7px] px-4 py-2 text-xs sm:h-9 sm:w-auto" disabled={!canJoinSessions}>
               {labels.go}
             </SubmitButton>
           </form>

--- a/components/dashboard/group-schedule-modal.tsx
+++ b/components/dashboard/group-schedule-modal.tsx
@@ -149,7 +149,7 @@ export function GroupScheduleModal({
                 <input type="hidden" name="groupId" value={groupId} />
 
                 <div className="space-y-2">
-                  <div className="grid grid-cols-[minmax(96px,1fr)_minmax(72px,0.8fr)_minmax(72px,0.8fr)_minmax(56px,0.6fr)_22px] items-center gap-2 px-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">
+                  <div className="grid grid-cols-[minmax(88px,1fr)_minmax(68px,0.75fr)_minmax(68px,0.75fr)_minmax(52px,0.55fr)_28px] items-center gap-2 px-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">
                     <span>{locale === 'fr' ? 'Jour' : 'Day'}</span>
                     <span>{locale === 'fr' ? 'Début' : 'Start'}</span>
                     <span>{locale === 'fr' ? 'Fin' : 'End'}</span>
@@ -159,7 +159,7 @@ export function GroupScheduleModal({
                   {drafts.map((draft) => (
                     <div key={draft.id} className="rounded-[9px] bg-white/[0.045] p-3 text-sm">
                       {mode === 'edit' ? <input type="hidden" name="scheduleId" value={draft.id} /> : null}
-                      <div className="grid grid-cols-[minmax(96px,1fr)_minmax(72px,0.8fr)_minmax(72px,0.8fr)_minmax(56px,0.6fr)_22px] items-center gap-2">
+                      <div className="grid grid-cols-[minmax(88px,1fr)_minmax(68px,0.75fr)_minmax(68px,0.75fr)_minmax(52px,0.55fr)_28px] items-center gap-2">
                         <label className="block min-w-0">
                           <select
                             name="weekday"
@@ -208,13 +208,13 @@ export function GroupScheduleModal({
                             aria-label={labels.questionGoal}
                           />
                         </label>
-                        <div className="flex justify-end">
+                        <div className="flex justify-center">
                           {draft.persisted ? (
-                            <button type="submit" formAction={deleteAction} name="deleteScheduleId" value={draft.id} className="button-ghost px-0 py-1 text-slate-500 hover:text-white" aria-label={labels.removeDay}>
+                            <button type="submit" formAction={deleteAction} name="deleteScheduleId" value={draft.id} className="flex h-8 w-8 items-center justify-center rounded-md text-slate-500 transition hover:bg-white/[0.06] hover:text-white" aria-label={labels.removeDay}>
                               <Trash2 className="h-4 w-4" aria-hidden="true" />
                             </button>
                           ) : (
-                            <button type="button" onClick={() => removeDraft(draft.id)} className="button-ghost px-0 py-1 text-slate-500 hover:text-white" aria-label={labels.removeDay}>
+                            <button type="button" onClick={() => removeDraft(draft.id)} className="flex h-8 w-8 items-center justify-center rounded-md text-slate-500 transition hover:bg-white/[0.06] hover:text-white" aria-label={labels.removeDay}>
                               <Trash2 className="h-4 w-4" aria-hidden="true" />
                             </button>
                           )}

--- a/components/groups/group-page-view.tsx
+++ b/components/groups/group-page-view.tsx
@@ -9,6 +9,7 @@ import { GroupEditModal } from '@/components/dashboard/group-edit-modal';
 import { GroupScheduleModal } from '@/components/dashboard/group-schedule-modal';
 import { InviteMemberForm } from '@/components/dashboard/group-settings-forms';
 import { LiveGroupsModal } from '@/components/dashboard/live-groups-modal';
+import { GroupSwitcherMenu } from '@/components/layout/group-switcher-menu';
 import { CalendarIcon, UsersIcon } from '@/components/ui/dashboard-icons';
 import type { AppLocale } from '@/i18n/routing';
 
@@ -47,6 +48,19 @@ type LiveGroup = {
 
 type GroupPageViewProps = {
   locale: AppLocale;
+  shellGroups: Array<{
+    id: string;
+    name: string;
+    language: string;
+    scheduleLabel: string;
+    weeklyQuestions: number;
+    membersPreview: Array<{
+      id: string;
+      initials: string;
+      avatarUrl: string | null;
+    }>;
+  }>;
+  currentUserInitials: string;
   canBrowseLookupLayer: boolean;
   initialLiveOpen: boolean;
   primaryGroup: {
@@ -68,6 +82,10 @@ type GroupPageViewProps = {
   canCreateSession: boolean;
   liveGroups: LiveGroup[];
   labels: {
+    myGroups: string;
+    activeGroup: string;
+    selectGroupHint: string;
+    noSchedule: string;
     newSession: string;
     createSession: string;
     createSessionPending: string;
@@ -164,6 +182,8 @@ function formatMeridiemTime(value: string) {
 
 export function GroupPageView({
   locale,
+  shellGroups,
+  currentUserInitials,
   canBrowseLookupLayer,
   initialLiveOpen,
   primaryGroup,
@@ -186,6 +206,20 @@ export function GroupPageView({
 
   return (
     <>
+      {shellGroups.length > 0 ? (
+        <GroupSwitcherMenu
+          groups={shellGroups}
+          userInitials={currentUserInitials}
+          labels={{
+            myGroups: labels.myGroups,
+            active: labels.activeGroup,
+            selectHint: labels.selectGroupHint,
+            noSchedule: labels.noSchedule,
+            averageWeekly: labels.averageWeeklyShort,
+          }}
+        />
+      ) : null}
+
       {canBrowseLookupLayer ? (
         <LiveGroupsModal
           locale={locale}

--- a/components/groups/group-page-view.tsx
+++ b/components/groups/group-page-view.tsx
@@ -30,6 +30,7 @@ type MemberPerformance = {
   completionRate: number;
   averageWeeklyQuestions: number;
   totalAnswers: number;
+  status: 'setup' | 'active';
 };
 
 type LiveGroup = {
@@ -157,6 +158,7 @@ type GroupPageViewProps = {
     memberCompletion: string;
     memberTotal: string;
     captainLabel: string;
+    memberStatusSetup: string;
     memberStatusActive: string;
     groupViewEmpty: string;
     groupAccessHint: string;
@@ -442,7 +444,12 @@ export function GroupPageView({
                       ) : null}
                     </div>
                     <div className="min-w-0">
-                      <p className="truncate text-sm font-bold text-white">{member.name}</p>
+                      <div className="flex items-center gap-2">
+                        <p className="truncate text-sm font-bold text-white">{member.name}</p>
+                        {member.userId === currentCaptainId ? (
+                          <span className="text-[11px] font-semibold text-amber-300">{labels.captainLabel}</span>
+                        ) : null}
+                      </div>
                       <div className="mt-1 flex items-center gap-2 text-xs text-slate-400">
                         <span className="rounded-full bg-white/[0.05] px-2 py-1">{labels.memberAverageWeekly.replace('{value}', String(member.averageWeeklyQuestions))}</span>
                         <span className="rounded-full bg-white/[0.05] px-2 py-1">{labels.memberCompletion.replace('{value}', String(member.completionRate))}</span>
@@ -451,7 +458,7 @@ export function GroupPageView({
                     </div>
                   </div>
                     <span className="rounded-full border border-brand/25 bg-brand/10 px-3 py-1 text-[10px] font-bold text-brand">
-                      {member.userId === currentCaptainId ? labels.captainLabel : labels.memberStatusActive}
+                      {member.status === 'setup' ? labels.memberStatusSetup : labels.memberStatusActive}
                     </span>
                   </div>
                 </div>

--- a/components/groups/group-page-view.tsx
+++ b/components/groups/group-page-view.tsx
@@ -52,6 +52,7 @@ type GroupPageViewProps = {
     id: string;
     name: string;
     language: string;
+    memberCount: number;
     scheduleLabel: string;
     weeklyQuestions: number;
     membersPreview: Array<{
@@ -465,15 +466,19 @@ export function GroupPageView({
       {isCreateSessionOpen && primaryGroup ? (
         <CreateSessionModal
           locale={locale}
-          groupId={primaryGroup.id}
-          memberCount={primaryGroup.memberCount}
+          groups={shellGroups.map((group) => ({
+            id: group.id,
+            name: group.name,
+            memberCount: group.memberCount,
+          }))}
+          initialGroupId={primaryGroup.id}
           canCreateSession={canCreateSession}
           action={actions.createSessionAction}
-          returnTo={groupPath}
           labels={{
             newSession: labels.newSession,
             createSession: labels.createSession,
             createSessionPending: labels.createSessionPending,
+            groupName: labels.groupName,
             sessionName: labels.sessionName,
             sessionNamePlaceholder: labels.sessionNamePlaceholder,
             questionCount: labels.questionCount,

--- a/components/groups/group-page-view.tsx
+++ b/components/groups/group-page-view.tsx
@@ -218,7 +218,7 @@ export function GroupPageView({
       ) : null}
 
       <section className="surface-mockup p-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
             <p className="truncate text-sm font-bold text-white">{primaryGroup?.name ?? labels.unknownGroup}</p>
             <p className="mt-1 break-words text-xs leading-5 text-slate-500">{groupInfoSummary}</p>
@@ -302,13 +302,13 @@ export function GroupPageView({
       </section>
 
       <section className="surface-mockup p-5">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-2">
             <CalendarIcon />
             <p className="text-sm font-bold text-white">{labels.scheduleAndGoalTitle}</p>
           </div>
           {isPrimaryGroupFounder && primaryGroup ? (
-            <div className="flex items-center gap-1">
+            <div className="flex shrink-0 items-center gap-1">
               <GroupScheduleModal
                 addAction={actions.addWeeklyScheduleAction}
                 updateAction={actions.updateWeeklySchedulesAction}

--- a/components/layout/group-switcher-menu.tsx
+++ b/components/layout/group-switcher-menu.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChevronDown, Lock, Users, X } from 'lucide-react';
+import { ChevronDown, Users, X } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { usePathname } from 'next/navigation';
 
@@ -23,8 +23,6 @@ type ShellGroup = {
 
 type GroupSwitcherMenuProps = {
   groups: ShellGroup[];
-  liveGroupCount: number;
-  liveHref: string;
   userInitials: string;
   labels: {
     myGroups: string;
@@ -37,14 +35,12 @@ type GroupSwitcherMenuProps = {
 
 const MEMBER_AVATAR_COLORS = ['#3b82f6', '#22c55e', '#a855f7', '#ef4444', '#f59e0b'];
 
-export function GroupSwitcherMenu({ groups, liveGroupCount, liveHref, userInitials, labels }: GroupSwitcherMenuProps) {
+export function GroupSwitcherMenu({ groups, userInitials, labels }: GroupSwitcherMenuProps) {
   const [open, setOpen] = useState(false);
   const [failedAvatarIds, setFailedAvatarIds] = useState<string[]>([]);
   const pathname = usePathname();
   const pathGroupId = pathname.match(/\/groups\/([^/?#]+)/)?.[1] ?? null;
   const selectedGroup = useMemo(() => groups.find((group) => group.id === pathGroupId) ?? null, [groups, pathGroupId]);
-  const resolvedLiveHref =
-    liveHref === '/groups?live=1' && selectedGroup ? `/groups/${selectedGroup.id}?live=1` : liveHref;
   const failedAvatarSet = useMemo(() => new Set(failedAvatarIds), [failedAvatarIds]);
 
   useEffect(() => {
@@ -62,59 +58,22 @@ export function GroupSwitcherMenu({ groups, liveGroupCount, liveHref, userInitia
 
   return (
     <>
-      <div className="hidden items-center gap-2 sm:flex">
-        <button
-          type="button"
-          onClick={() => setOpen(true)}
-          className="flex h-10 min-w-0 max-w-[290px] items-center gap-3 rounded-[10px] border border-white/[0.08] bg-[#11192c] px-3 text-left shadow-[inset_0_0_0_1px_rgba(255,255,255,0.015)] transition hover:border-white/15 hover:bg-[#131d32]"
-          aria-haspopup="dialog"
-          aria-expanded={open}
-        >
-          <span className="relative flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-[#176b55] bg-[#053b32] text-[10px] font-extrabold text-[#22e39c]">
-            {userInitials}
-            <span className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border border-[#11192c] bg-brand" />
-          </span>
-          <span className="min-w-0 flex-1 truncate text-sm font-extrabold text-white">
-            {selectedGroup?.name ?? labels.myGroups}
-          </span>
-          <ChevronDown className="h-4 w-4 shrink-0 text-slate-500" aria-hidden="true" strokeWidth={1.8} />
-        </button>
-        <Link
-          href={resolvedLiveHref}
-          className="inline-flex h-10 items-center gap-1.5 rounded-[8px] bg-amber-500/10 px-3 text-xs font-extrabold text-amber-400 ring-1 ring-amber-500/10 transition hover:bg-amber-500/15"
-          aria-label={`${liveGroupCount}`}
-        >
-          <Lock className="h-3.5 w-3.5" aria-hidden="true" strokeWidth={1.8} />
-          {liveGroupCount}
-        </Link>
-      </div>
-
-      <div className="flex min-w-0 flex-1 items-center gap-2 sm:hidden">
-        <button
-          type="button"
-          onClick={() => setOpen(true)}
-          className="flex h-10 min-w-0 flex-1 items-center gap-2 rounded-[10px] border border-white/[0.08] bg-[#11192c] px-3 text-left shadow-[inset_0_0_0_1px_rgba(255,255,255,0.015)] transition hover:border-white/15 hover:bg-[#131d32]"
-          aria-haspopup="dialog"
-          aria-expanded={open}
-        >
-          <span className="relative flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-[#176b55] bg-[#053b32] text-[10px] font-extrabold text-[#22e39c]">
-            {userInitials}
-            <span className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border border-[#11192c] bg-brand" />
-          </span>
-          <span className="min-w-0 flex-1 truncate text-sm font-extrabold text-white">
-            {selectedGroup?.name ?? labels.myGroups}
-          </span>
-          <ChevronDown className="h-4 w-4 shrink-0 text-slate-500" aria-hidden="true" strokeWidth={1.8} />
-        </button>
-        <Link
-          href={resolvedLiveHref}
-          className="inline-flex h-10 shrink-0 items-center gap-1.5 rounded-[8px] bg-amber-500/10 px-3 text-xs font-extrabold text-amber-400 ring-1 ring-amber-500/10 transition hover:bg-amber-500/15"
-          aria-label={`${liveGroupCount}`}
-        >
-          <Lock className="h-3.5 w-3.5" aria-hidden="true" strokeWidth={1.8} />
-          {liveGroupCount}
-        </Link>
-      </div>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex h-10 min-w-0 w-full items-center gap-3 rounded-[10px] border border-white/[0.08] bg-[#11192c] px-3 text-left shadow-[inset_0_0_0_1px_rgba(255,255,255,0.015)] transition hover:border-white/15 hover:bg-[#131d32]"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+      >
+        <span className="relative flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-[#176b55] bg-[#053b32] text-[10px] font-extrabold text-[#22e39c]">
+          {userInitials}
+          <span className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border border-[#11192c] bg-brand" />
+        </span>
+        <span className="min-w-0 flex-1 truncate text-sm font-extrabold text-white">
+          {selectedGroup?.name ?? labels.myGroups}
+        </span>
+        <ChevronDown className="h-4 w-4 shrink-0 text-slate-500" aria-hidden="true" strokeWidth={1.8} />
+      </button>
 
       {open ? (
         <ModalPortal>

--- a/components/layout/profile-menu.tsx
+++ b/components/layout/profile-menu.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { BookOpen, CreditCard, Globe, User } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState, useTransition } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { BookOpen, CreditCard, User } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 
 import { Link } from '@/i18n/navigation';
 import { cn } from '@/lib/utils';
@@ -12,14 +11,12 @@ type ProfileMenuProps = {
   name: string;
   email: string;
   isCaptain?: boolean;
-  locale: 'en' | 'fr';
   profileHref?: string | null;
   profileLabel?: string | null;
   examHref?: string | null;
   examLabel?: string | null;
   billingHref?: string | null;
   billingLabel?: string | null;
-  languageLabel: string;
 };
 
 export function ProfileMenu({
@@ -27,21 +24,15 @@ export function ProfileMenu({
   name,
   email,
   isCaptain = false,
-  locale,
   profileHref,
   profileLabel,
   examHref,
   examLabel,
   billingHref,
   billingLabel,
-  languageLabel,
 }: ProfileMenuProps) {
   const [open, setOpen] = useState(false);
-  const [isPending, startTransition] = useTransition();
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const searchParams = useSearchParams();
-  const search = useMemo(() => searchParams.toString(), [searchParams]);
-  const nextLocale = locale === 'en' ? 'fr' : 'en';
 
   useEffect(() => {
     function handlePointerDown(event: MouseEvent) {
@@ -125,24 +116,6 @@ export function ProfileMenu({
                 <span>{billingLabel}</span>
               </Link>
             ) : null}
-          </div>
-
-          <div className="border-t border-white/[0.06] py-1">
-            <button
-              type="button"
-              disabled={isPending}
-              onClick={() => {
-                setOpen(false);
-                startTransition(() => {
-                  const localizedPath = window.location.pathname.replace(/^\/(en|fr)(?=\/|$)/, `/${nextLocale}`);
-                  window.location.assign(search ? `${localizedPath}?${search}` : localizedPath);
-                });
-              }}
-              className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-bold text-slate-300 transition hover:bg-white/[0.05] hover:text-white disabled:opacity-60"
-            >
-              <Globe className="h-4 w-4 text-slate-500" aria-hidden="true" strokeWidth={1.7} />
-              <span>{languageLabel}</span>
-            </button>
           </div>
         </div>
       ) : null}

--- a/components/onboarding/create-group-wizard.tsx
+++ b/components/onboarding/create-group-wizard.tsx
@@ -466,7 +466,7 @@ export function CreateGroupWizard({ locale, labels, initialProfile, isAuthentica
               </label>
               {scheduleEnabled ? (
                 <div className="space-y-3">
-                  <div className="grid grid-cols-[minmax(96px,1.2fr)_minmax(72px,0.85fr)_minmax(72px,0.85fr)_minmax(56px,0.65fr)_20px] items-center gap-2 px-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">
+                  <div className="grid grid-cols-[minmax(88px,1fr)_minmax(64px,0.72fr)_minmax(64px,0.72fr)_minmax(50px,0.5fr)_28px] items-center gap-2 px-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">
                     <span>{locale === 'fr' ? 'Jour' : 'Day'}</span>
                     <span>{locale === 'fr' ? 'Début' : 'Start'}</span>
                     <span>{locale === 'fr' ? 'Fin' : 'End'}</span>
@@ -475,7 +475,7 @@ export function CreateGroupWizard({ locale, labels, initialProfile, isAuthentica
                   </div>
                   {slots.map((slot) => (
                     <div key={slot.id} className="rounded-[10px] bg-[#111827] p-3 sm:p-4">
-                      <div className="grid grid-cols-[minmax(96px,1.2fr)_minmax(72px,0.85fr)_minmax(72px,0.85fr)_minmax(56px,0.65fr)_20px] items-center gap-2">
+                      <div className="grid grid-cols-[minmax(88px,1fr)_minmax(64px,0.72fr)_minmax(64px,0.72fr)_minmax(50px,0.5fr)_28px] items-center gap-2">
                         <label className="block min-w-0">
                           <select value={slot.weekday} onChange={(event) => updateSlot(slot.id, { weekday: event.target.value })} className="field-compact rounded-[6px] px-3 text-sm">
                             {WEEKDAYS.map((weekday) => (
@@ -494,7 +494,11 @@ export function CreateGroupWizard({ locale, labels, initialProfile, isAuthentica
                         <label className="block min-w-0">
                           <input value={slot.questionGoal} onChange={(event) => updateSlot(slot.id, { questionGoal: event.target.value })} type="number" min="1" className="field-compact rounded-[6px] px-3 text-center text-sm" />
                         </label>
-                        <button type="button" onClick={() => setSlots((current) => (current.length > 1 ? current.filter((item) => item.id !== slot.id) : current))} className="justify-self-end rounded-md p-1 text-slate-500 hover:text-white">
+                        <button
+                          type="button"
+                          onClick={() => setSlots((current) => (current.length > 1 ? current.filter((item) => item.id !== slot.id) : current))}
+                          className="flex h-8 w-8 items-center justify-center justify-self-center rounded-md text-slate-500 transition hover:bg-white/[0.06] hover:text-white"
+                        >
                           <Trash2 className="h-4 w-4" aria-hidden="true" />
                         </button>
                       </div>

--- a/components/sessions/create-session-modal.tsx
+++ b/components/sessions/create-session-modal.tsx
@@ -9,6 +9,7 @@ export type CreateSessionModalLabels = {
   newSession: string;
   createSession: string;
   createSessionPending: string;
+  groupName: string;
   sessionName: string;
   sessionNamePlaceholder: string;
   questionCount: string;
@@ -24,24 +25,23 @@ export type CreateSessionModalLabels = {
 
 export function CreateSessionModal({
   locale,
-  groupId,
-  memberCount,
+  groups,
+  initialGroupId,
   canCreateSession,
   action,
-  returnTo,
   labels,
   onClose,
 }: {
   locale: string;
-  groupId: string;
-  memberCount: number;
+  groups: Array<{ id: string; name: string; memberCount: number }>;
+  initialGroupId: string;
   canCreateSession: boolean;
   action: (formData: FormData) => void | Promise<void>;
-  returnTo: string;
   labels: CreateSessionModalLabels;
   onClose: () => void;
 }) {
   const [name, setName] = useState('');
+  const [selectedGroupId, setSelectedGroupId] = useState(initialGroupId);
   const [questionGoal, setQuestionGoal] = useState('10');
   const [timerMode, setTimerMode] = useState<'per_question' | 'global'>('per_question');
   const [timerSeconds, setTimerSeconds] = useState('90');
@@ -59,8 +59,13 @@ export function CreateSessionModal({
     setTimerSeconds(value === 'global' ? '600' : '90');
   };
 
+  const selectedGroup = groups.find((group) => group.id === selectedGroupId) ?? groups[0] ?? null;
+  const memberCount = selectedGroup?.memberCount ?? 0;
+  const returnTo = selectedGroup ? `/${locale}/groups/${selectedGroup.id}` : `/${locale}/groups`;
+
   const isValid =
     canCreateSession &&
+    Boolean(selectedGroupId) &&
     memberCount >= 2 &&
     name.trim().length > 0 &&
     Number(questionGoal) > 0 &&
@@ -78,8 +83,23 @@ export function CreateSessionModal({
 
         <form action={action} className="mt-5 space-y-4">
           <input type="hidden" name="locale" value={locale} />
-          <input type="hidden" name="groupId" value={groupId} />
           <input type="hidden" name="returnTo" value={returnTo} />
+
+          <label className="block">
+            <span className="text-sm font-bold text-slate-300">{labels.groupName}</span>
+            <select
+              name="groupId"
+              value={selectedGroupId}
+              onChange={(event) => setSelectedGroupId(event.target.value)}
+              className="field mt-2 h-10 rounded-[7px] px-3 py-2 text-sm"
+            >
+              {groups.map((group) => (
+                <option key={group.id} value={group.id}>
+                  {group.name}
+                </option>
+              ))}
+            </select>
+          </label>
 
           <label className="block">
             <span className="text-sm font-bold text-slate-300">{labels.sessionName}</span>

--- a/lib/demo/data.ts
+++ b/lib/demo/data.ts
@@ -955,10 +955,14 @@ export const getGroupData = cache(async (groupId: string, user: User) => {
     };
   });
 
-  const currentCaptainId =
+  const founderCaptainId =
+    safeMembers.find((member) => member.is_founder)?.user_id ??
+    null;
+  const sessionLeaderId =
     safeSessions.find((session) => session.status === 'active')?.leader_id ??
     safeSessions.find((session) => session.status === 'scheduled')?.leader_id ??
     null;
+  const currentCaptainId = founderCaptainId ?? sessionLeaderId ?? null;
 
   perf.done({
     members: safeMembers.length,

--- a/lib/demo/data.ts
+++ b/lib/demo/data.ts
@@ -949,7 +949,9 @@ export const getGroupData = cache(async (groupId: string, user: User) => {
       completionRate: totalTrackableQuestions > 0 ? Math.round(((answerStats?.questionIds.size ?? 0) / totalTrackableQuestions) * 100) : 0,
       averageWeeklyQuestions: Math.round(totalAnswers / Math.max(1, activeWeekKeys.size)),
       totalAnswers,
-      status: (answerStats?.sessionIds.size ?? 0) === 0 && (answerStats?.questionIds.size ?? 0) === 0 ? 'setup' : 'active',
+      status: ((answerStats?.sessionIds.size ?? 0) === 0 && (answerStats?.questionIds.size ?? 0) === 0 ? 'setup' : 'active') as
+        | 'setup'
+        | 'active',
     };
   });
 


### PR DESCRIPTION
## Summary

This PR groups the recent group/session logic refactor into a single branch.

The goal is to make group scope explicit, reduce hidden global group behavior in the shell, and align session creation with the updated product direction.

## What changed

- removed the group switcher from the global app shell
- moved group switching into the `Groups` tab scope
- kept the live-groups pill available in the global header
- updated session creation so the group is selected explicitly in the creation flow
- kept session creation scoped to group workflows rather than restoring a dashboard-level "new session" flow
- aligned group member rendering so captain labeling is distinct from performance/status badges
- exposed the language switcher directly in the global header instead of hiding it in the profile menu

## Product intent

This refactor removes the impression that a group is globally active across the whole app.

After this change:
- group context lives in `Groups`
- sessions and performance remain transverse/global views
- live access remains globally exposed through the header pill
- creating a session requires choosing the target group explicitly




