### PR TITLE
Add shared modal primitive and migrate app dialogs

### DIFF
--- a/components/dashboard/group-edit-modal.tsx
+++ b/components/dashboard/group-edit-modal.tsx
@@ -3,7 +3,7 @@
 import { Pencil, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
-import { ModalPortal } from '@/components/ui/modal-portal';
+import { Modal, ModalTitle } from '@/components/ui/modal';
 import { SubmitButton } from '@/components/ui/submit-button';
 
 type GroupEditModalProps = {
@@ -61,15 +61,18 @@ export function GroupEditModal({
       </button>
 
       {open ? (
-        <ModalPortal>
-        <div className="fixed inset-0 flex items-end justify-center bg-black/72 px-0 py-0 backdrop-blur-[2px] sm:items-center sm:px-4 sm:py-6" style={{ zIndex: 1000 }} role="dialog" aria-modal="true">
-          <button type="button" className="absolute inset-0 cursor-default" aria-label={labels.close} onClick={() => setOpen(false)} />
-          <section className="relative max-h-[min(88vh,620px)] w-full max-w-[480px] overflow-y-auto rounded-t-[16px] border border-white/[0.06] bg-[#11192c] p-4 shadow-[0_30px_90px_rgba(0,0,0,0.55)] [scrollbar-width:none] sm:rounded-[10px] sm:p-6 [&::-webkit-scrollbar]:hidden">
+        <Modal
+          open={open}
+          onClose={() => setOpen(false)}
+          backdropLabel={labels.close}
+          mobileSheet
+          contentClassName="relative max-h-[min(88vh,620px)] w-full max-w-[480px] overflow-y-auto rounded-t-[16px] border border-white/[0.06] bg-[#11192c] p-4 shadow-[0_30px_90px_rgba(0,0,0,0.55)] [scrollbar-width:none] sm:rounded-[10px] sm:p-6 [&::-webkit-scrollbar]:hidden"
+        >
             <div className="flex items-center justify-between gap-4">
-              <h2 className="flex items-center gap-2 text-xl font-extrabold tracking-tight text-white">
+              <ModalTitle className="flex items-center gap-2 text-xl font-extrabold tracking-tight text-white">
                 <Pencil className="h-4 w-4 text-brand" aria-hidden="true" strokeWidth={1.8} />
                 {labels.title}
-              </h2>
+              </ModalTitle>
               <button type="button" onClick={() => setOpen(false)} className="rounded-md p-1 text-slate-400 transition hover:bg-white/[0.06] hover:text-white" aria-label={labels.close}>
                 <X className="h-5 w-5" aria-hidden="true" strokeWidth={1.8} />
               </button>
@@ -111,9 +114,7 @@ export function GroupEditModal({
                 </SubmitButton>
               </div>
             </form>
-          </section>
-        </div>
-        </ModalPortal>
+        </Modal>
       ) : null}
     </>
   );

--- a/components/dashboard/group-schedule-modal.tsx
+++ b/components/dashboard/group-schedule-modal.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { CalendarDays, Pencil, Trash2, X } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
-import { ModalPortal } from '@/components/ui/modal-portal';
+import { Modal, ModalTitle } from '@/components/ui/modal';
 import { SubmitButton } from '@/components/ui/submit-button';
 
 type Schedule = {
@@ -90,15 +90,6 @@ export function GroupScheduleModal({
   const [drafts, setDrafts] = useState<ScheduleDraft[]>([]);
   const slotLabel = locale === 'fr' ? 'Ajouter un créneau' : 'Add slot';
 
-  useEffect(() => {
-    if (!open) return;
-    function handleEscape(event: KeyboardEvent) {
-      if (event.key === 'Escape') setOpen(false);
-    }
-    document.addEventListener('keydown', handleEscape);
-    return () => document.removeEventListener('keydown', handleEscape);
-  }, [open]);
-
   function openModal(nextMode: ModalMode) {
     setMode(nextMode);
     setDrafts(nextMode === 'edit' && schedules.length > 0 ? schedules.map(scheduleToDraft) : [createDraft(0)]);
@@ -127,16 +118,19 @@ export function GroupScheduleModal({
       </button>
 
       {open ? (
-        <ModalPortal>
-          <div className="fixed inset-0 flex items-end justify-center bg-black/72 px-0 py-0 backdrop-blur-[2px] sm:items-center sm:px-4 sm:py-6" style={{ zIndex: 1000 }} role="dialog" aria-modal="true">
-            <button type="button" className="absolute inset-0 cursor-default" aria-label={labels.close} onClick={() => setOpen(false)} />
-            <section className="relative max-h-[min(88vh,620px)] w-full max-w-[540px] overflow-y-auto rounded-t-[16px] border border-white/[0.06] bg-[#11192c] p-4 shadow-[0_30px_90px_rgba(0,0,0,0.55)] [scrollbar-width:none] sm:rounded-[10px] sm:p-6 [&::-webkit-scrollbar]:hidden">
+        <Modal
+          open={open}
+          onClose={() => setOpen(false)}
+          backdropLabel={labels.close}
+          mobileSheet
+          contentClassName="relative max-h-[min(88vh,620px)] w-full max-w-[540px] overflow-y-auto rounded-t-[16px] border border-white/[0.06] bg-[#11192c] p-4 shadow-[0_30px_90px_rgba(0,0,0,0.55)] [scrollbar-width:none] sm:rounded-[10px] sm:p-6 [&::-webkit-scrollbar]:hidden"
+        >
               <div className="flex items-start justify-between gap-4">
                 <div>
-                  <h2 className="flex items-center gap-2 text-xl font-extrabold tracking-tight text-white">
+                  <ModalTitle className="flex items-center gap-2 text-xl font-extrabold tracking-tight text-white">
                     <CalendarDays className="h-4 w-4 text-brand" aria-hidden="true" strokeWidth={1.8} />
                     {labels.title}
-                  </h2>
+                  </ModalTitle>
                   <p className="mt-2 text-sm font-medium text-slate-400">{labels.description}</p>
                 </div>
                 <button type="button" onClick={() => setOpen(false)} className="rounded-md p-1 text-slate-400 transition hover:bg-white/[0.06] hover:text-white" aria-label={labels.close}>
@@ -237,9 +231,7 @@ export function GroupScheduleModal({
                   </SubmitButton>
                 </div>
               </form>
-            </section>
-          </div>
-        </ModalPortal>
+        </Modal>
       ) : null}
     </>
   );

--- a/components/dashboard/live-groups-modal.tsx
+++ b/components/dashboard/live-groups-modal.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Lock } from 'lucide-react';
 
 import { Link, usePathname, useRouter } from '@/i18n/navigation';
 import { SubmitButton } from '@/components/ui/submit-button';
-import { ModalPortal } from '@/components/ui/modal-portal';
+import { Modal, ModalTitle } from '@/components/ui/modal';
 
 type LiveGroup = {
   id: string;
@@ -89,21 +89,6 @@ export function LiveGroupsModal({ locale, groups, canJoinLiveGroups, initialOpen
   const pathname = usePathname();
   const router = useRouter();
 
-  useEffect(() => {
-    if (initialOpen) {
-      setOpen(true);
-    }
-  }, [initialOpen]);
-
-  useEffect(() => {
-    if (!open) return;
-    function handleEscape(event: KeyboardEvent) {
-      if (event.key === 'Escape') setOpen(false);
-    }
-    document.addEventListener('keydown', handleEscape);
-    return () => document.removeEventListener('keydown', handleEscape);
-  }, [open]);
-
   function handleClose() {
     setOpen(false);
     if (typeof window === 'undefined') {
@@ -132,15 +117,18 @@ export function LiveGroupsModal({ locale, groups, canJoinLiveGroups, initialOpen
       </button>
 
       {open ? (
-        <ModalPortal>
-        <div className="fixed inset-0 flex items-end justify-center bg-black/70 px-0 backdrop-blur-[2px] sm:px-4 sm:py-6" style={{ zIndex: 1000 }}>
-          <button type="button" className="absolute inset-0 cursor-default" aria-label={labels.close} onClick={handleClose} />
-          <section className="relative max-h-[82vh] w-full max-w-[548px] animate-in slide-in-from-bottom-4 overflow-y-auto rounded-t-[16px] border border-white/[0.08] bg-[#11192c] p-5 shadow-[0_-24px_80px_rgba(0,0,0,0.6)] duration-200 [scrollbar-width:none] sm:rounded-[14px] [&::-webkit-scrollbar]:hidden">
+        <Modal
+          open={open}
+          onClose={handleClose}
+          backdropLabel={labels.close}
+          mobileSheet
+          contentClassName="relative max-h-[82vh] w-full max-w-[548px] animate-in slide-in-from-bottom-4 overflow-y-auto rounded-t-[16px] border border-white/[0.08] bg-[#11192c] p-5 shadow-[0_-24px_80px_rgba(0,0,0,0.6)] duration-200 [scrollbar-width:none] sm:rounded-[14px] [&::-webkit-scrollbar]:hidden"
+        >
             <div className="flex items-center justify-between">
-              <h2 className="flex items-center gap-2 text-lg font-extrabold text-white">
+              <ModalTitle className="flex items-center gap-2 text-lg font-extrabold text-white">
                 <span className="h-2.5 w-2.5 rounded-full bg-red-500 shadow-[0_0_0_4px_rgba(239,68,68,0.08)]" />
                 {labels.title}
-              </h2>
+              </ModalTitle>
               <button type="button" onClick={handleClose} className="text-2xl leading-none text-slate-400 hover:text-white" aria-label={labels.close}>
                 x
               </button>
@@ -222,9 +210,7 @@ export function LiveGroupsModal({ locale, groups, canJoinLiveGroups, initialOpen
                 </div>
               ) : null}
             </div>
-          </section>
-        </div>
-        </ModalPortal>
+        </Modal>
       ) : null}
     </>
   );

--- a/components/sessions/create-session-modal.tsx
+++ b/components/sessions/create-session-modal.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Clock } from 'lucide-react';
 
+import { Modal, ModalTitle } from '@/components/ui/modal';
 import { SubmitButton } from '@/components/ui/submit-button';
 
 export type CreateSessionModalLabels = {
@@ -46,14 +47,6 @@ export function CreateSessionModal({
   const [timerMode, setTimerMode] = useState<'per_question' | 'global'>('per_question');
   const [timerSeconds, setTimerSeconds] = useState('90');
 
-  useEffect(() => {
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = previousOverflow;
-    };
-  }, []);
-
   const updateTimerMode = (value: 'per_question' | 'global') => {
     setTimerMode(value);
     setTimerSeconds(value === 'global' ? '600' : '90');
@@ -67,10 +60,15 @@ export function CreateSessionModal({
     Number(timerSeconds) > 0;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center overflow-y-auto bg-black/60 px-0 backdrop-blur-[2px] [scrollbar-width:none] sm:items-center sm:px-4 [&::-webkit-scrollbar]:hidden">
-      <div className="max-h-[90vh] w-full max-w-[478px] overflow-y-auto rounded-t-[18px] bg-[#111827] p-4 shadow-2xl ring-1 ring-white/[0.08] [scrollbar-width:none] sm:rounded-[14px] sm:p-6 [&::-webkit-scrollbar]:hidden">
+    <Modal
+      open
+      onClose={onClose}
+      backdropLabel={labels.close}
+      mobileSheet
+      contentClassName="max-h-[90vh] w-full max-w-[478px] overflow-y-auto rounded-t-[18px] bg-[#111827] p-4 shadow-2xl ring-1 ring-white/[0.08] [scrollbar-width:none] sm:rounded-[14px] sm:p-6 [&::-webkit-scrollbar]:hidden"
+    >
         <div className="flex items-center justify-between">
-          <h2 className="text-lg font-extrabold text-white">{labels.newSession}</h2>
+          <ModalTitle className="text-lg font-extrabold text-white">{labels.newSession}</ModalTitle>
           <button type="button" onClick={onClose} className="rounded-md p-1 text-slate-400 hover:text-white" aria-label={labels.close}>
             x
           </button>
@@ -161,7 +159,6 @@ export function CreateSessionModal({
             {labels.createSession}
           </SubmitButton>
         </form>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/components/ui/modal.tsx
+++ b/components/ui/modal.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { type ReactNode, useEffect, useId, useRef } from 'react';
+
+import { ModalPortal } from '@/components/ui/modal-portal';
+import { cn } from '@/lib/utils';
+
+type ModalProps = {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  mobileSheet?: boolean;
+  closeOnBackdrop?: boolean;
+  labelledBy?: string;
+  describedBy?: string;
+  initialFocusRef?: React.RefObject<HTMLElement>;
+};
+
+function getFocusableElements(container: HTMLElement) {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      [
+        'a[href]',
+        'button:not([disabled])',
+        'textarea:not([disabled])',
+        'input:not([disabled])',
+        'select:not([disabled])',
+        '[tabindex]:not([tabindex="-1"])',
+      ].join(','),
+    ),
+  ).filter((element) => !element.hasAttribute('disabled') && element.getAttribute('aria-hidden') !== 'true');
+}
+
+export function Modal({
+  open,
+  onClose,
+  children,
+  className,
+  contentClassName,
+  mobileSheet = true,
+  closeOnBackdrop = true,
+  labelledBy,
+  describedBy,
+  initialFocusRef,
+}: ModalProps) {
+  const internalTitleId = useId();
+  const dialogRef = useRef<HTMLElement | null>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    restoreFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const dialogElement = dialogRef.current;
+    const focusTarget =
+      initialFocusRef?.current ??
+      (dialogElement ? getFocusableElements(dialogElement)[0] : null) ??
+      dialogElement;
+
+    window.setTimeout(() => {
+      focusTarget?.focus();
+    }, 0);
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== 'Tab' || !dialogRef.current) {
+        return;
+      }
+
+      const focusable = getFocusableElements(dialogRef.current);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialogRef.current.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (!first || !last) {
+        return;
+      }
+      const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+      if (event.shiftKey) {
+        if (activeElement === first || activeElement === dialogRef.current) {
+          event.preventDefault();
+          last.focus();
+        }
+        return;
+      }
+
+      if (activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener('keydown', handleKeyDown);
+      restoreFocusRef.current?.focus();
+    };
+  }, [initialFocusRef, onClose, open]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <ModalPortal>
+      <div
+        className={cn(
+          'fixed inset-0 flex justify-center bg-black/72 px-0 py-0 backdrop-blur-[2px] sm:px-4 sm:py-6',
+          mobileSheet ? 'items-end sm:items-center' : 'items-center',
+          className,
+        )}
+        style={{ zIndex: 1000 }}
+      >
+        <button
+          type="button"
+          className="absolute inset-0 cursor-default"
+          aria-label="Close"
+          onClick={closeOnBackdrop ? onClose : undefined}
+        />
+        <section
+          ref={(node) => {
+            dialogRef.current = node;
+          }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={labelledBy ?? internalTitleId}
+          aria-describedby={describedBy}
+          tabIndex={-1}
+          className={cn(contentClassName)}
+        >
+          {children}
+        </section>
+      </div>
+    </ModalPortal>
+  );
+}
+
+type ModalTitleProps = {
+  id?: string;
+  className?: string;
+  children: ReactNode;
+};
+
+export function ModalTitle({ id, className, children }: ModalTitleProps) {
+  return (
+    <h2 id={id} className={className}>
+      {children}
+    </h2>
+  );
+}

--- a/components/ui/modal.tsx
+++ b/components/ui/modal.tsx
@@ -13,6 +13,7 @@ type ModalProps = {
   contentClassName?: string;
   mobileSheet?: boolean;
   closeOnBackdrop?: boolean;
+  backdropLabel?: string;
   labelledBy?: string;
   describedBy?: string;
   initialFocusRef?: React.RefObject<HTMLElement>;
@@ -41,6 +42,7 @@ export function Modal({
   contentClassName,
   mobileSheet = true,
   closeOnBackdrop = true,
+  backdropLabel = 'Close',
   labelledBy,
   describedBy,
   initialFocusRef,
@@ -132,7 +134,7 @@ export function Modal({
         <button
           type="button"
           className="absolute inset-0 cursor-default"
-          aria-label="Close"
+          aria-label={backdropLabel}
           onClick={closeOnBackdrop ? onClose : undefined}
         />
         <section


### PR DESCRIPTION
## Summary

This PR implements ticket `#91` by introducing a shared modal primitive and migrating the app dialogs that were still using ad-hoc modal wrappers.

The main goal is to standardize modal behavior across the app:
- desktop centering
- mobile bottom-sheet support
- `Escape` dismissal
- backdrop-click dismissal
- focus trap
- restore focus on close
- dialog accessibility attributes

## What changed

### Shared modal primitive
Added a reusable modal primitive in:
- `components/ui/modal.tsx`

It now standardizes:
- `role="dialog"` + `aria-modal`
- desktop-centered layout
- optional mobile bottom-sheet behavior
- `Escape` to close
- backdrop click to close
- focus trap while open
- restore focus on close

### Dialog migrations
Migrated these dialogs to the shared primitive:
- `components/dashboard/live-groups-modal.tsx`
- `components/sessions/create-session-modal.tsx`
- `components/dashboard/group-schedule-modal.tsx`
- `components/dashboard/group-edit-modal.tsx`

## Ticket alignment

This closes the core acceptance criteria for `#91`:

- [x] A shared modal primitive exists
- [x] Live groups modal is vertically centered on desktop
- [x] Pressing `Escape` closes open modals
- [x] Clicking the backdrop closes open modals
- [x] Focus is trapped inside the modal and restored on close

