### PR TITLE
Stabilize Supabase Realtime connections and reduce websocket churn

### DIFF
--- a/app/[locale]/dashboard/page.tsx
+++ b/app/[locale]/dashboard/page.tsx
@@ -2,7 +2,6 @@ import { getTranslations } from 'next-intl/server';
 import { redirect } from 'next/navigation';
 
 import { FeedbackBanner } from '@/components/app/feedback-banner';
-import { RealtimeRefresh } from '@/components/app/realtime-refresh';
 import { DashboardPerformanceView } from '@/components/dashboard/dashboard-performance-view';
 import { DashboardSessionsView } from '@/components/dashboard/dashboard-sessions-view';
 import type { AppLocale } from '@/i18n/routing';
@@ -58,23 +57,8 @@ export default async function DashboardPage({ params, searchParams }: DashboardP
     showWarning: (billingSnapshot?.questions_answered ?? 0) >= 85 && (billingSnapshot?.questions_answered ?? 0) < TRIAL_QUESTION_LIMIT,
     isComplete: (billingSnapshot?.questions_answered ?? 0) >= TRIAL_QUESTION_LIMIT,
   };
-  const activeGroupId =
-    sessionsData?.groups.find((group) => group.is_founder)?.id ?? sessionsData?.groups[0]?.id ?? null;
-
   return (
     <main className="flex flex-1 flex-col gap-5">
-      {activeGroupId ? (
-        <RealtimeRefresh
-          channelName={`dashboard:${activeGroupId}`}
-          tables={[
-            { table: 'group_members', filter: `group_id=eq.${activeGroupId}` },
-            { table: 'group_weekly_schedules', filter: `group_id=eq.${activeGroupId}` },
-            { table: 'sessions', filter: `group_id=eq.${activeGroupId}` },
-          ]}
-          throttleMs={700}
-        />
-      ) : null}
-
       <FeedbackBanner message={searchParams.feedbackMessage} tone={searchParams.feedbackTone} />
 
       <section className="mx-auto w-full max-w-[620px] space-y-4">

--- a/app/[locale]/groups/[groupId]/page.tsx
+++ b/app/[locale]/groups/[groupId]/page.tsx
@@ -1,7 +1,6 @@
 import { getTranslations } from 'next-intl/server';
 
 import { FeedbackBanner } from '@/components/app/feedback-banner';
-import { RealtimeRefresh } from '@/components/app/realtime-refresh';
 import { GroupPageView } from '@/components/groups/group-page-view';
 import type { AppLocale } from '@/i18n/routing';
 import { requireUser } from '@/lib/auth';
@@ -236,18 +235,6 @@ export default async function GroupRoutePage({
 
   return (
     <main className="flex flex-1 flex-col gap-5">
-      {primaryGroup ? (
-        <RealtimeRefresh
-          channelName={`dashboard:${primaryGroup.id}`}
-          tables={[
-            { table: 'group_members', filter: `group_id=eq.${primaryGroup.id}` },
-            { table: 'group_weekly_schedules', filter: `group_id=eq.${primaryGroup.id}` },
-            { table: 'sessions', filter: `group_id=eq.${primaryGroup.id}` },
-          ]}
-          throttleMs={700}
-        />
-      ) : null}
-
       <FeedbackBanner message={searchParams.feedbackMessage} tone={searchParams.feedbackTone} />
 
       <section className="mx-auto w-full max-w-[620px] space-y-4">

--- a/app/[locale]/sessions/[sessionId]/page.tsx
+++ b/app/[locale]/sessions/[sessionId]/page.tsx
@@ -170,7 +170,6 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
   if (shouldShowCompletion) {
     return (
       <main className="flex flex-1 items-center justify-center px-4">
-        <RealtimeRefresh channelName={`session:${params.sessionId}`} tables={realtimeTables} />
         <FeedbackBanner message={searchParams.feedbackMessage} tone={searchParams.feedbackTone} />
         <section className="flex w-full max-w-md flex-col items-center text-center">
           <div className="flex h-16 w-16 items-center justify-center rounded-full bg-brand/10 text-brand">
@@ -202,7 +201,6 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
 
     return (
       <main className="flex flex-1 flex-col">
-        <RealtimeRefresh channelName={`session:${params.sessionId}`} tables={realtimeTables} />
         <FeedbackBanner message={searchParams.feedbackMessage} tone={searchParams.feedbackTone} />
         <header className="sticky top-0 z-20 border-b border-white/[0.07] bg-background/95 backdrop-blur">
           <div className="mx-auto flex min-h-16 w-full max-w-[700px] flex-wrap items-center justify-between gap-3 px-4 py-3 sm:h-16 sm:flex-nowrap sm:py-0">

--- a/components/app/realtime-refresh.tsx
+++ b/components/app/realtime-refresh.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 
+import { registerRealtimeSubscription } from '@/lib/realtime/browser';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 
 type RealtimeTable = {
@@ -32,29 +33,20 @@ export function RealtimeRefresh({ channelName, tables, throttleMs = 450 }: Realt
       }, throttleMs);
     };
 
-    const channel = supabase.channel(channelName);
     const parsedTables = JSON.parse(tablesKey) as RealtimeTable[];
-
-    for (const item of parsedTables) {
-      channel.on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: item.table,
-          filter: item.filter,
-        },
-        scheduleRefresh,
-      );
-    }
-
-    channel.subscribe();
+    const release = registerRealtimeSubscription({
+      supabase,
+      channelName,
+      tables: parsedTables,
+      onEvent: scheduleRefresh,
+    });
 
     return () => {
       if (refreshTimerRef.current !== null) {
         window.clearTimeout(refreshTimerRef.current);
+        refreshTimerRef.current = null;
       }
-      void supabase.removeChannel(channel);
+      void release();
     };
   }, [channelName, router, supabase, tablesKey, throttleMs]);
 

--- a/lib/realtime/browser.ts
+++ b/lib/realtime/browser.ts
@@ -1,0 +1,147 @@
+'use client';
+
+import type { RealtimeChannel } from '@supabase/supabase-js';
+
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+
+type RealtimeTable = {
+  table: string;
+  filter?: string;
+};
+
+type RealtimeCallback = () => void;
+
+type RegistryEntry = {
+  channel: RealtimeChannel;
+  subscribers: number;
+  callbacks: Set<RealtimeCallback>;
+};
+
+const realtimeRegistry = new Map<string, RegistryEntry>();
+
+function logRealtime(event: string, metadata: Record<string, unknown>) {
+  if (process.env.NODE_ENV === 'production') {
+    return;
+  }
+
+  console.info('[realtime]', event, metadata);
+}
+
+function getRegistryKey(channelName: string, tables: RealtimeTable[]) {
+  return JSON.stringify({
+    channelName,
+    tables: tables.map((table) => ({
+      table: table.table,
+      filter: table.filter ?? null,
+    })),
+  });
+}
+
+function wireChannelSubscriptions(channel: RealtimeChannel, tables: RealtimeTable[], notify: () => void) {
+  for (const table of tables) {
+    channel.on(
+      'postgres_changes',
+      {
+        event: '*',
+        schema: 'public',
+        table: table.table,
+        filter: table.filter,
+      },
+      notify,
+    );
+  }
+}
+
+export function registerRealtimeSubscription({
+  supabase,
+  channelName,
+  tables,
+  onEvent,
+}: {
+  supabase: ReturnType<typeof createSupabaseBrowserClient>;
+  channelName: string;
+  tables: RealtimeTable[];
+  onEvent: RealtimeCallback;
+}) {
+  const registryKey = getRegistryKey(channelName, tables);
+  const existingEntry = realtimeRegistry.get(registryKey);
+
+  if (existingEntry) {
+    existingEntry.subscribers += 1;
+    existingEntry.callbacks.add(onEvent);
+    logRealtime('subscription_reused', {
+      channelName,
+      registryKey,
+      subscribers: existingEntry.subscribers,
+    });
+
+    return async () => {
+      existingEntry.callbacks.delete(onEvent);
+      existingEntry.subscribers -= 1;
+
+      logRealtime('subscription_released', {
+        channelName,
+        registryKey,
+        subscribers: existingEntry.subscribers,
+      });
+
+      if (existingEntry.subscribers <= 0) {
+        realtimeRegistry.delete(registryKey);
+        await supabase.removeChannel(existingEntry.channel);
+        logRealtime('channel_removed', { channelName, registryKey });
+      }
+    };
+  }
+
+  const callbacks = new Set<RealtimeCallback>([onEvent]);
+  const notify = () => {
+    for (const callback of callbacks) {
+      callback();
+    }
+  };
+
+  const channel = supabase.channel(channelName);
+  wireChannelSubscriptions(channel, tables, notify);
+
+  channel.subscribe((status) => {
+    logRealtime('channel_status', {
+      channelName,
+      registryKey,
+      status,
+    });
+  });
+
+  realtimeRegistry.set(registryKey, {
+    channel,
+    subscribers: 1,
+    callbacks,
+  });
+
+  logRealtime('channel_created', {
+    channelName,
+    registryKey,
+    tables: tables.map((table) => ({ table: table.table, filter: table.filter ?? null })),
+  });
+
+  return async () => {
+    const entry = realtimeRegistry.get(registryKey);
+    if (!entry) {
+      return;
+    }
+
+    entry.callbacks.delete(onEvent);
+    entry.subscribers -= 1;
+
+    logRealtime('subscription_released', {
+      channelName,
+      registryKey,
+      subscribers: entry.subscribers,
+    });
+
+    if (entry.subscribers <= 0) {
+      realtimeRegistry.delete(registryKey);
+      await supabase.removeChannel(entry.channel);
+      logRealtime('channel_removed', { channelName, registryKey });
+    }
+  };
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -5,8 +5,29 @@ import { createBrowserClient } from '@supabase/ssr';
 import { getBrowserEnv } from '@/lib/env';
 import type { Database } from '@/lib/supabase/types';
 
+type BrowserSupabaseClient = ReturnType<typeof createBrowserClient<Database>>;
+
+let browserSupabaseClient: BrowserSupabaseClient | undefined;
+
 export function createSupabaseBrowserClient() {
+  if (browserSupabaseClient !== undefined) {
+    return browserSupabaseClient;
+  }
+
   const { supabaseUrl, supabaseAnonKey } = getBrowserEnv();
 
-  return createBrowserClient<Database>(supabaseUrl, supabaseAnonKey);
+  browserSupabaseClient = createBrowserClient<Database>(supabaseUrl, supabaseAnonKey, {
+    realtime: {
+      timeout: 10_000,
+      heartbeatIntervalMs: 15_000,
+      reconnectAfterMs(tries: number) {
+        if (tries <= 1) return 1_000;
+        if (tries === 2) return 2_000;
+        if (tries === 3) return 4_000;
+        return 8_000;
+      },
+    },
+  });
+
+  return browserSupabaseClient;
 }


### PR DESCRIPTION
## Summary

This PR addresses the Realtime WebSocket stability ticket by reducing duplicate browser clients, centralizing subscription lifecycle, bounding reconnect behavior, and removing unnecessary Realtime listeners from non-critical routes.

The goal is to stop WebSocket connection storms from degrading route responsiveness and overall app fluidity.

## What changed

### 1. Browser Supabase client lifecycle
- switched the browser Supabase client to a singleton
- prevents multiple independent Realtime clients/sockets from being created across route transitions and client components

### 2. Shared Realtime subscription registry
- added a shared browser-side Realtime registry
- identical channel/topic subscriptions are reused instead of recreated
- subscriptions are reference-counted and removed only when the last consumer unmounts
- added dev instrumentation for:
  - channel creation
  - subscription reuse
  - subscription release
  - channel removal
  - channel status changes

### 3. Bounded Realtime behavior
- added a shorter Realtime timeout
- added bounded reconnect delays
- keeps Realtime failures from hanging as aggressively as before

### 4. Reduced Realtime scope
Removed non-critical Realtime listeners from:
- dashboard
- groups/[groupId]
- session review/completion screens

Realtime now remains only on session views where live updates are still materially useful.

## Ticket alignment

- [x] No route creates duplicate Realtime subscriptions for the same channel
- [x] Realtime subscriptions are removed cleanly on unmount / route change
- [x] WebSocket connection storms are reduced during normal navigation
- [x] Realtime fail/reconnect behavior is bounded and no longer intentionally waits 20s+ per attempt
- [x] Views that do not need live updates do not keep unnecessary Realtime channels open
- [x] Navigation remains usable even if Realtime is degraded or unavailable


