### PR TITLE
Reduce aborted RSC navigations by deferring non-critical route work

### DIFF
--- a/app/[locale]/groups/[groupId]/page.tsx
+++ b/app/[locale]/groups/[groupId]/page.tsx
@@ -97,7 +97,6 @@ export default async function GroupRoutePage({
     sunday: t('weekdaySunday'),
   };
 
-  const currentGroupIds = new Set(memberships.map((membership) => membership.group_id));
   const shellGroups =
     memberships.length > 0
       ? await (async () => {
@@ -163,77 +162,6 @@ export default async function GroupRoutePage({
           });
         })()
       : [];
-  const liveGroups =
-    canBrowseLookupLayer && primaryGroup
-      ? await (async () => {
-          const supabaseAdmin = createSupabaseAdminClient();
-          const { data: candidateGroups } = await supabaseAdmin
-            .schema('public')
-            .from('groups')
-            .select('id, name, invite_code, max_members, created_at')
-            .order('created_at', { ascending: false })
-            .limit(20);
-          const availableGroups = (candidateGroups ?? []).filter((group) => !currentGroupIds.has(group.id));
-          const availableGroupIds = availableGroups.map((group) => group.id);
-          if (availableGroupIds.length === 0) return [];
-
-          const [{ data: memberships }, { data: schedules }] = await Promise.all([
-            supabaseAdmin
-              .schema('public')
-              .from('group_members')
-              .select('group_id, user_id')
-              .in('group_id', availableGroupIds),
-            supabaseAdmin
-              .schema('public')
-              .from('group_weekly_schedules')
-              .select('group_id, question_goal')
-              .in('group_id', availableGroupIds),
-          ]);
-
-          const ids = [...new Set((memberships ?? []).map((membership) => membership.user_id))];
-          const { data: users } =
-            ids.length > 0
-              ? await supabaseAdmin.schema('public').from('users').select('id, display_name, email').in('id', ids)
-              : { data: [] };
-          const usersMap = new Map((users ?? []).map((profile) => [profile.id, profile]));
-
-          const membersByGroup = new Map<string, Array<{ user_id: string }>>();
-          for (const membership of memberships ?? []) {
-            const current = membersByGroup.get(membership.group_id) ?? [];
-            current.push({ user_id: membership.user_id });
-            membersByGroup.set(membership.group_id, current);
-          }
-
-          const weeklyByGroup = new Map<string, number>();
-          for (const schedule of schedules ?? []) {
-            weeklyByGroup.set(schedule.group_id, (weeklyByGroup.get(schedule.group_id) ?? 0) + schedule.question_goal);
-          }
-
-          return availableGroups
-            .map((group) => {
-              const members = membersByGroup.get(group.id) ?? [];
-              return {
-                id: group.id,
-                name: group.name,
-                inviteCode: group.invite_code,
-                memberCount: members.length,
-                maxMembers: group.max_members,
-                language: locale.toUpperCase(),
-                timezone: '',
-                weeklyQuestions: weeklyByGroup.get(group.id) ?? 0,
-                minutesAgo: Math.max(1, Math.round((Date.now() - new Date(group.created_at).getTime()) / 60000)),
-                compatible: true,
-                members: members.slice(0, 5).map((member) => {
-                  const profile = usersMap.get(member.user_id);
-                  const label = profile?.display_name ?? profile?.email ?? 'AB';
-                  return { id: member.user_id, initials: getInitials(label) };
-                }),
-              };
-            })
-            .filter((group) => group.memberCount < group.maxMembers);
-        })()
-      : [];
-
   return (
     <main className="flex flex-1 flex-col gap-5">
       {primaryGroup ? (
@@ -268,7 +196,6 @@ export default async function GroupRoutePage({
           groupInfoSummary={groupInfoSummary}
           sessions={data.sessions}
           canCreateSession={canCreateSession}
-          liveGroups={liveGroups}
           labels={{
             myGroups: t('myGroups'),
             activeGroup: t('activeGroup'),

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -2,11 +2,11 @@ import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, getTranslations, setRequestLocale } from 'next-intl/server';
-import { Lock } from 'lucide-react';
 
 import { AppBottomNav } from '@/components/layout/app-bottom-nav';
 import { HomeHeaderNav } from '@/components/layout/home-header-nav';
 import { LanguageSwitcher } from '@/components/layout/language-switcher';
+import { LiveGroupsPill } from '@/components/layout/live-groups-pill';
 import { ProfileMenu } from '@/components/layout/profile-menu';
 import { OfflineStatusBanner } from '@/components/pwa/offline-status-banner';
 import { RegisterServiceWorker } from '@/components/pwa/register-service-worker';
@@ -14,7 +14,6 @@ import { Link } from '@/i18n/navigation';
 import { routing, type AppLocale } from '@/i18n/routing';
 import { getCurrentUser } from '@/lib/auth';
 import { getUserAccessState, hasUserTierCapability } from '@/lib/billing/gating';
-import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 export function generateStaticParams() {
@@ -44,33 +43,16 @@ export default async function LocaleLayout({
   const shellData = user
       ? await (async () => {
         const supabase = createSupabaseServerClient();
-        const supabaseAdmin = createSupabaseAdminClient();
         const accessState = await getUserAccessState(user.id);
         const canBrowseLookupLayer = hasUserTierCapability(accessState, 'canBrowseLookupLayer');
         const { data: memberships } = await supabase
           .schema('public')
           .from('group_members')
-          .select('group_id')
+          .select('group_id, joined_at')
           .eq('user_id', user.id);
-        const groupIds = [...new Set((memberships ?? []).map((membership) => membership.group_id))];
-        const { data: candidateGroups } = await supabaseAdmin
-          .schema('public')
-          .from('groups')
-          .select('id, max_members')
-          .order('created_at', { ascending: false })
-          .limit(30);
-        const candidateGroupIds = (candidateGroups ?? []).map((group) => group.id);
-        const { data: candidateMemberships } =
-          candidateGroupIds.length > 0
-            ? await supabaseAdmin.schema('public').from('group_members').select('group_id').in('group_id', candidateGroupIds)
-            : { data: [] };
-        const candidateCounts = new Map<string, number>();
-        for (const membership of candidateMemberships ?? []) {
-          candidateCounts.set(membership.group_id, (candidateCounts.get(membership.group_id) ?? 0) + 1);
-        }
-        const liveGroupCount = (candidateGroups ?? []).filter(
-          (group) => !groupIds.includes(group.id) && (candidateCounts.get(group.id) ?? 0) < (group.max_members ?? 5),
-        ).length;
+        const preferredGroupId =
+          [...(memberships ?? [])]
+            .sort((left, right) => new Date(right.joined_at).getTime() - new Date(left.joined_at).getTime())[0]?.group_id ?? null;
         const { data: captainSession } = await supabase
           .schema('public')
           .from('sessions')
@@ -81,11 +63,11 @@ export default async function LocaleLayout({
           .maybeSingle();
         return {
           isCaptain: Boolean(captainSession),
-          liveGroupCount,
           canBrowseLookupLayer,
+          preferredGroupId,
         };
       })()
-    : { isCaptain: false, liveGroupCount: 0, canBrowseLookupLayer: false };
+    : { isCaptain: false, canBrowseLookupLayer: false, preferredGroupId: null as string | null };
   const displayName = user?.user_metadata.full_name ?? user?.email ?? 'ActiveBoard';
   const initials =
     displayName
@@ -129,14 +111,11 @@ export default async function LocaleLayout({
                   >
                     <LanguageSwitcher />
                   </Suspense>
-                  <Link
-                    href={shellData.canBrowseLookupLayer ? '/groups?live=1' : '/billing'}
-                    className="inline-flex h-10 items-center gap-1.5 rounded-[8px] bg-amber-500/10 px-3 text-xs font-extrabold text-amber-400 ring-1 ring-amber-500/10 transition hover:bg-amber-500/15"
-                    aria-label={`${dashboardT('joinLiveGroups')} ${shellData.liveGroupCount}`}
-                  >
-                    <Lock className="h-3.5 w-3.5" aria-hidden="true" strokeWidth={1.8} />
-                    {shellData.liveGroupCount}
-                  </Link>
+                  <LiveGroupsPill
+                    href={shellData.canBrowseLookupLayer ? `${shellData.preferredGroupId ? `/groups/${shellData.preferredGroupId}` : '/groups'}?live=1` : '/billing'}
+                    label={dashboardT('joinLiveGroups')}
+                    canBrowseLookupLayer={shellData.canBrowseLookupLayer}
+                  />
                   <ProfileMenu
                     initials={initials}
                     name={displayName}
@@ -176,6 +155,7 @@ export default async function LocaleLayout({
         {user ? (
           <AppBottomNav
             locale={locale}
+            groupsHref={shellData.preferredGroupId ? `/groups/${shellData.preferredGroupId}` : '/groups'}
             labels={{
               sessions: t('navSessions'),
               performance: t('navPerformance'),

--- a/app/api/live-groups/count/route.ts
+++ b/app/api/live-groups/count/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+
+import { getUserAccessState, hasUserTierCapability } from '@/lib/billing/gating';
+import { getLiveGroupCountForUser } from '@/lib/live-groups/server';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+export async function GET() {
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ ok: false, reason: 'unauthorized' }, { status: 401 });
+  }
+
+  const accessState = await getUserAccessState(user.id);
+  const canBrowseLookupLayer = hasUserTierCapability(accessState, 'canBrowseLookupLayer');
+
+  if (!canBrowseLookupLayer) {
+    return NextResponse.json({ ok: true, count: 0 });
+  }
+
+  const count = await getLiveGroupCountForUser(user.id);
+  return NextResponse.json({ ok: true, count });
+}

--- a/app/api/live-groups/route.ts
+++ b/app/api/live-groups/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+
+import { getUserAccessState, hasUserTierCapability } from '@/lib/billing/gating';
+import { type AppLocale, routing } from '@/i18n/routing';
+import { getLiveGroupsForUser } from '@/lib/live-groups/server';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+export async function GET(request: Request) {
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ ok: false, reason: 'unauthorized' }, { status: 401 });
+  }
+
+  const accessState = await getUserAccessState(user.id);
+  const canBrowseLookupLayer = hasUserTierCapability(accessState, 'canBrowseLookupLayer');
+
+  if (!canBrowseLookupLayer) {
+    return NextResponse.json({ ok: true, groups: [] });
+  }
+
+  const url = new URL(request.url);
+  const localeParam = url.searchParams.get('locale');
+  const locale: AppLocale = routing.locales.includes(localeParam as AppLocale)
+    ? (localeParam as AppLocale)
+    : routing.defaultLocale;
+
+  const groups = await getLiveGroupsForUser(user.id, locale);
+  return NextResponse.json({ ok: true, groups });
+}

--- a/components/dashboard/live-groups-modal.tsx
+++ b/components/dashboard/live-groups-modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Lock } from 'lucide-react';
 
 import { Link, usePathname, useRouter } from '@/i18n/navigation';
@@ -23,7 +23,6 @@ type LiveGroup = {
 
 type LiveGroupsModalProps = {
   locale: string;
-  groups: LiveGroup[];
   canJoinLiveGroups: boolean;
   initialOpen?: boolean;
   joinGroupAction: (formData: FormData) => void | Promise<void>;
@@ -84,10 +83,48 @@ function formatElapsedTime(minutes: number, labels: LiveGroupsModalProps['labels
   return labels.yearsAgo.replace('{count}', String(Math.floor(months / 12)));
 }
 
-export function LiveGroupsModal({ locale, groups, canJoinLiveGroups, initialOpen = false, joinGroupAction, labels }: LiveGroupsModalProps) {
+export function LiveGroupsModal({ locale, canJoinLiveGroups, initialOpen = false, joinGroupAction, labels }: LiveGroupsModalProps) {
   const [open, setOpen] = useState(initialOpen);
+  const [groups, setGroups] = useState<LiveGroup[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
   const pathname = usePathname();
   const router = useRouter();
+
+  useEffect(() => {
+    if (!open || !canJoinLiveGroups) {
+      return;
+    }
+
+    const controller = new AbortController();
+    setIsLoading(true);
+
+    void fetch(`/api/live-groups?locale=${locale}`, {
+      cache: 'no-store',
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          return null;
+        }
+
+        return (await response.json()) as { ok?: boolean; groups?: LiveGroup[] } | null;
+      })
+      .then((payload) => {
+        if (payload?.ok && Array.isArray(payload.groups)) {
+          setGroups(payload.groups);
+        }
+      })
+      .catch(() => {
+        setGroups([]);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [canJoinLiveGroups, locale, open]);
 
   function handleClose() {
     setOpen(false);
@@ -135,7 +172,13 @@ export function LiveGroupsModal({ locale, groups, canJoinLiveGroups, initialOpen
             </div>
 
             <div className="mt-5 space-y-3">
-              {groups.length === 0 ? (
+              {isLoading ? (
+                <div className="rounded-[12px] border border-white/[0.06] bg-[#18243a] p-4 text-sm font-semibold text-slate-400">
+                  Loading...
+                </div>
+              ) : null}
+
+              {!isLoading && groups.length === 0 ? (
                 <div className="rounded-[12px] border border-white/[0.06] bg-[#18243a] p-4 text-sm font-semibold text-slate-400">
                   {labels.empty}
                 </div>

--- a/components/groups/group-page-view.tsx
+++ b/components/groups/group-page-view.tsx
@@ -33,20 +33,6 @@ type MemberPerformance = {
   status: 'setup' | 'active';
 };
 
-type LiveGroup = {
-  id: string;
-  name: string;
-  inviteCode: string;
-  memberCount: number;
-  maxMembers: number;
-  language: string;
-  timezone: string;
-  weeklyQuestions: number;
-  minutesAgo: number;
-  compatible: boolean;
-  members: Array<{ id: string; initials: string }>;
-};
-
 type GroupPageViewProps = {
   locale: AppLocale;
   shellGroups: Array<{
@@ -82,7 +68,6 @@ type GroupPageViewProps = {
   groupInfoSummary: string;
   sessions: SessionListItem[];
   canCreateSession: boolean;
-  liveGroups: LiveGroup[];
   labels: {
     myGroups: string;
     activeGroup: string;
@@ -200,7 +185,6 @@ export function GroupPageView({
   groupInfoSummary,
   sessions,
   canCreateSession,
-  liveGroups,
   labels,
   actions,
 }: GroupPageViewProps) {
@@ -226,7 +210,6 @@ export function GroupPageView({
       {canBrowseLookupLayer ? (
         <LiveGroupsModal
           locale={locale}
-          groups={liveGroups}
           canJoinLiveGroups={canBrowseLookupLayer}
           initialOpen={initialLiveOpen}
           joinGroupAction={actions.joinGroupAction}

--- a/components/layout/app-bottom-nav.tsx
+++ b/components/layout/app-bottom-nav.tsx
@@ -46,17 +46,31 @@ export function AppBottomNav({ locale, groupsHref = '/groups', labels }: AppBott
         {items.map((item) => {
           const Icon = item.Icon;
           const active = item.key === 'group' ? isGroupsPath : isDashboardPath && dashboardView === item.key;
+          const className = cn(
+            'flex min-h-[60px] flex-col items-center justify-center gap-1 rounded-[10px] border px-1.5 text-[10px] font-medium transition sm:text-[11px]',
+            active && 'border-brand/80 bg-brand/[0.12] text-brand shadow-[inset_0_0_0_1px_rgba(16,185,129,0.42),0_0_18px_rgba(16,185,129,0.12)]',
+            !active && 'border-transparent text-slate-500 hover:border-brand/35 hover:bg-brand/[0.04] hover:text-brand',
+          );
+
+          if (active) {
+            return (
+              <div
+                key={item.key}
+                aria-current="page"
+                className={className}
+              >
+                <Icon className="h-5 w-5" aria-hidden="true" />
+                <span>{labels[item.key]}</span>
+              </div>
+            );
+          }
 
           return (
             <Link
               key={item.key}
               href={item.href}
               prefetch={false}
-              className={cn(
-                'flex min-h-[60px] flex-col items-center justify-center gap-1 rounded-[10px] border px-1.5 text-[10px] font-medium transition sm:text-[11px]',
-                active && 'border-brand/80 bg-brand/[0.12] text-brand shadow-[inset_0_0_0_1px_rgba(16,185,129,0.42),0_0_18px_rgba(16,185,129,0.12)]',
-                !active && 'border-transparent text-slate-500 hover:border-brand/35 hover:bg-brand/[0.04] hover:text-brand',
-              )}
+              className={className}
             >
               <Icon className="h-5 w-5" aria-hidden="true" />
               <span>{labels[item.key]}</span>

--- a/components/layout/app-bottom-nav.tsx
+++ b/components/layout/app-bottom-nav.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/lib/utils';
 
 type AppBottomNavProps = {
   locale: string;
+  groupsHref?: string;
   labels: {
     sessions: string;
     performance: string;
@@ -15,30 +16,29 @@ type AppBottomNavProps = {
   };
 };
 
-const items = [
-  {
-    key: 'sessions',
-    href: '/dashboard?view=sessions',
-    Icon: Play,
-  },
-  {
-    key: 'performance',
-    href: '/dashboard?view=performance',
-    Icon: BarChart3,
-  },
-  {
-    key: 'group',
-    href: '/groups',
-    Icon: Users,
-  },
-] as const;
-
-export function AppBottomNav({ locale, labels }: AppBottomNavProps) {
+export function AppBottomNav({ locale, groupsHref = '/groups', labels }: AppBottomNavProps) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const dashboardView = searchParams.get('view') ?? 'sessions';
   const isDashboardPath = pathname === `/${locale}/dashboard` || pathname === '/dashboard';
   const isGroupsPath = pathname === `/${locale}/groups` || pathname.startsWith(`/${locale}/groups/`) || pathname === '/groups';
+  const items = [
+    {
+      key: 'sessions',
+      href: '/dashboard?view=sessions',
+      Icon: Play,
+    },
+    {
+      key: 'performance',
+      href: '/dashboard?view=performance',
+      Icon: BarChart3,
+    },
+    {
+      key: 'group',
+      href: groupsHref,
+      Icon: Users,
+    },
+  ] as const;
 
   return (
     <nav className="fixed inset-x-0 bottom-0 z-40 border-t border-white/10 bg-[#060a16]/95 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 backdrop-blur-xl sm:px-3 sm:pb-[calc(0.75rem+env(safe-area-inset-bottom))]">

--- a/components/layout/live-groups-pill.tsx
+++ b/components/layout/live-groups-pill.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Lock } from 'lucide-react';
+
+import { Link } from '@/i18n/navigation';
+
+export function LiveGroupsPill({
+  href,
+  label,
+  canBrowseLookupLayer,
+  initialCount = 0,
+}: {
+  href: string;
+  label: string;
+  canBrowseLookupLayer: boolean;
+  initialCount?: number;
+}) {
+  const [count, setCount] = useState(initialCount);
+
+  useEffect(() => {
+    if (!canBrowseLookupLayer) {
+      setCount(0);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    void fetch('/api/live-groups/count', {
+      signal: controller.signal,
+      cache: 'no-store',
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          return null;
+        }
+
+        return (await response.json()) as { ok?: boolean; count?: number } | null;
+      })
+      .then((payload) => {
+        if (payload?.ok && typeof payload.count === 'number') {
+          setCount(payload.count);
+        }
+      })
+      .catch(() => {
+        // Non-critical shell hint. Ignore transient failures.
+      });
+
+    return () => controller.abort();
+  }, [canBrowseLookupLayer]);
+
+  return (
+    <Link
+      href={href}
+      className="inline-flex h-10 items-center gap-1.5 rounded-[8px] bg-amber-500/10 px-3 text-xs font-extrabold text-amber-400 ring-1 ring-amber-500/10 transition hover:bg-amber-500/15"
+      aria-label={`${label} ${count}`}
+    >
+      <Lock className="h-3.5 w-3.5" aria-hidden="true" strokeWidth={1.8} />
+      {count}
+    </Link>
+  );
+}

--- a/lib/live-groups/server.ts
+++ b/lib/live-groups/server.ts
@@ -1,0 +1,138 @@
+import type { AppLocale } from '@/i18n/routing';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+export type LiveGroupItem = {
+  id: string;
+  name: string;
+  inviteCode: string;
+  memberCount: number;
+  maxMembers: number;
+  language: string;
+  timezone: string;
+  weeklyQuestions: number;
+  minutesAgo: number;
+  compatible: boolean;
+  members: Array<{ id: string; initials: string }>;
+};
+
+function getInitials(value: string) {
+  return (
+    value
+      .split(' ')
+      .map((part) => part[0])
+      .join('')
+      .slice(0, 2)
+      .toUpperCase() || 'AB'
+  );
+}
+
+async function getCurrentUserGroupIds(userId: string) {
+  const supabase = createSupabaseServerClient();
+  const { data: memberships } = await supabase
+    .schema('public')
+    .from('group_members')
+    .select('group_id')
+    .eq('user_id', userId);
+
+  return [...new Set((memberships ?? []).map((membership) => membership.group_id))];
+}
+
+export async function getLiveGroupCountForUser(userId: string) {
+  const currentGroupIds = await getCurrentUserGroupIds(userId);
+  const supabaseAdmin = createSupabaseAdminClient();
+  const { data: candidateGroups } = await supabaseAdmin
+    .schema('public')
+    .from('groups')
+    .select('id, max_members')
+    .order('created_at', { ascending: false })
+    .limit(30);
+
+  const candidateGroupIds = (candidateGroups ?? []).map((group) => group.id);
+  const { data: candidateMemberships } =
+    candidateGroupIds.length > 0
+      ? await supabaseAdmin.schema('public').from('group_members').select('group_id').in('group_id', candidateGroupIds)
+      : { data: [] };
+
+  const candidateCounts = new Map<string, number>();
+  for (const membership of candidateMemberships ?? []) {
+    candidateCounts.set(membership.group_id, (candidateCounts.get(membership.group_id) ?? 0) + 1);
+  }
+
+  return (candidateGroups ?? []).filter(
+    (group) => !currentGroupIds.includes(group.id) && (candidateCounts.get(group.id) ?? 0) < (group.max_members ?? 5),
+  ).length;
+}
+
+export async function getLiveGroupsForUser(userId: string, locale: AppLocale): Promise<LiveGroupItem[]> {
+  const currentGroupIds = new Set(await getCurrentUserGroupIds(userId));
+  const supabaseAdmin = createSupabaseAdminClient();
+  const { data: candidateGroups } = await supabaseAdmin
+    .schema('public')
+    .from('groups')
+    .select('id, name, invite_code, max_members, created_at')
+    .order('created_at', { ascending: false })
+    .limit(20);
+
+  const availableGroups = (candidateGroups ?? []).filter((group) => !currentGroupIds.has(group.id));
+  const availableGroupIds = availableGroups.map((group) => group.id);
+
+  if (availableGroupIds.length === 0) {
+    return [];
+  }
+
+  const [{ data: memberships }, { data: schedules }] = await Promise.all([
+    supabaseAdmin
+      .schema('public')
+      .from('group_members')
+      .select('group_id, user_id')
+      .in('group_id', availableGroupIds),
+    supabaseAdmin
+      .schema('public')
+      .from('group_weekly_schedules')
+      .select('group_id, question_goal')
+      .in('group_id', availableGroupIds),
+  ]);
+
+  const ids = [...new Set((memberships ?? []).map((membership) => membership.user_id))];
+  const { data: users } =
+    ids.length > 0
+      ? await supabaseAdmin.schema('public').from('users').select('id, display_name, email').in('id', ids)
+      : { data: [] };
+  const usersMap = new Map((users ?? []).map((profile) => [profile.id, profile]));
+
+  const membersByGroup = new Map<string, Array<{ user_id: string }>>();
+  for (const membership of memberships ?? []) {
+    const current = membersByGroup.get(membership.group_id) ?? [];
+    current.push({ user_id: membership.user_id });
+    membersByGroup.set(membership.group_id, current);
+  }
+
+  const weeklyByGroup = new Map<string, number>();
+  for (const schedule of schedules ?? []) {
+    weeklyByGroup.set(schedule.group_id, (weeklyByGroup.get(schedule.group_id) ?? 0) + schedule.question_goal);
+  }
+
+  return availableGroups
+    .map((group) => {
+      const members = membersByGroup.get(group.id) ?? [];
+      return {
+        id: group.id,
+        name: group.name,
+        inviteCode: group.invite_code,
+        memberCount: members.length,
+        maxMembers: group.max_members,
+        language: locale.toUpperCase(),
+        timezone: '',
+        weeklyQuestions: weeklyByGroup.get(group.id) ?? 0,
+        minutesAgo: Math.max(1, Math.round((Date.now() - new Date(group.created_at).getTime()) / 60000)),
+        compatible: true,
+        members: members.slice(0, 5).map((member) => {
+          const profile = usersMap.get(member.user_id);
+          const label = profile?.display_name ?? profile?.email ?? 'AB';
+          return { id: member.user_id, initials: getInitials(label) };
+        }),
+      } satisfies LiveGroupItem;
+    })
+    .filter((group) => group.memberCount < group.maxMembers);
+}


### PR DESCRIPTION
## Summary

This PR addresses the tab-navigation RSC abort ticket by reducing non-critical work on route transitions and removing avoidable navigation churn.

The main goal is to make switching between Sessions, Performance, and Groups feel more responsive on mobile by tightening the initial route workload.

## What changed

### 1. Direct Groups navigation
- the bottom navigation no longer routes through `/groups` and then server-redirects to `/groups/[id]`
- it now links directly to the user's current group when available

### 2. Live pill cost moved off the critical route path
- the global header no longer computes the live-group count inside the server layout render path
- the count is now fetched client-side after render
- this removes heavy candidate-group counting work from every authenticated route transition

### 3. Live groups list no longer blocks Group page render
- the groups page no longer preloads live-group candidates during initial server render
- the live groups modal now fetches its content only when opened
- this keeps the feature while removing its cost from the tab-switch critical path

### 4. Redundant tab navigations removed
- the active bottom-nav tab is no longer rendered as a navigable link
- tapping the already-active tab no longer triggers unnecessary RSC work

## Ticket alignment

- [x] Switching between Sessions / Performance / Groups is more responsive
- [x] Aborted RSC navigations are reduced during normal tab switching
- [x] Major tab transitions no longer include as much non-critical initial route work
- [x] Expensive route work is more tightly bounded to what the route actually needs
- [x] Navigation remains responsive even when background activity is present


