### PR TITLE
Reduce authenticated route loading cost and defer non-critical data

### DIFF
--- a/app/[locale]/dashboard/page.tsx
+++ b/app/[locale]/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { DashboardPerformanceView } from '@/components/dashboard/dashboard-perfo
 import { DashboardSessionsView } from '@/components/dashboard/dashboard-sessions-view';
 import type { AppLocale } from '@/i18n/routing';
 import { requireUser } from '@/lib/auth';
-import { getUserBillingSnapshot, TRIAL_QUESTION_LIMIT } from '@/lib/billing/user-tier';
+import { getTrialProgressSnapshot, getUserBillingSnapshot } from '@/lib/billing/user-tier';
 import { getUserAccessState, hasUserTierCapability } from '@/lib/billing/gating';
 import { getDashboardPerformanceData, getDashboardSessionsData } from '@/lib/demo/data';
 
@@ -50,13 +50,7 @@ export default async function DashboardPage({ params, searchParams }: DashboardP
 
   const canJoinSessions = isSessionsView && accessState ? hasUserTierCapability(accessState, 'canJoinSessions') : false;
   const canCreateSession = isSessionsView && accessState ? hasUserTierCapability(accessState, 'canCreateSession') : false;
-  const trialProgress = {
-    current: Math.min(billingSnapshot?.questions_answered ?? 0, TRIAL_QUESTION_LIMIT),
-    total: TRIAL_QUESTION_LIMIT,
-    remaining: Math.max(TRIAL_QUESTION_LIMIT - (billingSnapshot?.questions_answered ?? 0), 0),
-    showWarning: (billingSnapshot?.questions_answered ?? 0) >= 85 && (billingSnapshot?.questions_answered ?? 0) < TRIAL_QUESTION_LIMIT,
-    isComplete: (billingSnapshot?.questions_answered ?? 0) >= TRIAL_QUESTION_LIMIT,
-  };
+  const trialProgress = getTrialProgressSnapshot(billingSnapshot?.questions_answered ?? 0);
   return (
     <main className="flex flex-1 flex-col gap-5">
       <FeedbackBanner message={searchParams.feedbackMessage} tone={searchParams.feedbackTone} />

--- a/app/[locale]/dashboard/page.tsx
+++ b/app/[locale]/dashboard/page.tsx
@@ -45,12 +45,12 @@ export default async function DashboardPage({ params, searchParams }: DashboardP
   const [sessionsData, performanceData, accessState, billingSnapshot] = await Promise.all([
     isSessionsView ? getDashboardSessionsData(user) : null,
     isPerformanceView ? getDashboardPerformanceData(user.id) : null,
-    getUserAccessState(user.id),
-    getUserBillingSnapshot(user.id),
+    isSessionsView ? getUserAccessState(user.id) : null,
+    isSessionsView ? getUserBillingSnapshot(user.id) : null,
   ]);
 
-  const canJoinSessions = hasUserTierCapability(accessState, 'canJoinSessions');
-  const canCreateSession = hasUserTierCapability(accessState, 'canCreateSession');
+  const canJoinSessions = isSessionsView && accessState ? hasUserTierCapability(accessState, 'canJoinSessions') : false;
+  const canCreateSession = isSessionsView && accessState ? hasUserTierCapability(accessState, 'canCreateSession') : false;
   const trialProgress = {
     current: Math.min(billingSnapshot?.questions_answered ?? 0, TRIAL_QUESTION_LIMIT),
     total: TRIAL_QUESTION_LIMIT,

--- a/app/[locale]/groups/[groupId]/page.tsx
+++ b/app/[locale]/groups/[groupId]/page.tsx
@@ -6,8 +6,7 @@ import { GroupPageView } from '@/components/groups/group-page-view';
 import type { AppLocale } from '@/i18n/routing';
 import { requireUser } from '@/lib/auth';
 import { getUserAccessState, hasUserTierCapability } from '@/lib/billing/gating';
-import { getGroupData } from '@/lib/demo/data';
-import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { getGroupCoreData } from '@/lib/demo/data';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 import {
@@ -46,8 +45,8 @@ export default async function GroupRoutePage({
   const canBrowseLookupLayer = hasUserTierCapability(accessState, 'canBrowseLookupLayer');
   const canCreateSession = hasUserTierCapability(accessState, 'canCreateSession');
 
-  const [data, currentProfile, memberships] = await Promise.all([
-    getGroupData(params.groupId, user),
+  const [data, currentProfile] = await Promise.all([
+    getGroupCoreData(params.groupId, user),
     createSupabaseServerClient()
       .schema('public')
       .from('users')
@@ -55,12 +54,6 @@ export default async function GroupRoutePage({
       .eq('id', user.id)
       .maybeSingle()
       .then((result) => result.data),
-    createSupabaseServerClient()
-      .schema('public')
-      .from('group_members')
-      .select('group_id')
-      .eq('user_id', user.id)
-      .then((result) => result.data ?? []),
   ]);
 
   if (!data) {
@@ -97,143 +90,6 @@ export default async function GroupRoutePage({
     sunday: t('weekdaySunday'),
   };
 
-  const currentGroupIds = new Set(memberships.map((membership) => membership.group_id));
-  const shellGroups =
-    memberships.length > 0
-      ? await (async () => {
-          const supabase = createSupabaseServerClient();
-          const supabaseAdmin = createSupabaseAdminClient();
-          const groupIds = [...new Set(memberships.map((membership) => membership.group_id))];
-          const [{ data: groups }, { data: schedules }, { data: membershipsWithUsers }] = await Promise.all([
-            supabase
-              .schema('public')
-              .from('groups')
-              .select('id, name')
-              .in('id', groupIds)
-              .order('created_at', { ascending: false }),
-            supabase
-              .schema('public')
-              .from('group_weekly_schedules')
-              .select('group_id, start_time, end_time, question_goal')
-              .in('group_id', groupIds),
-            supabaseAdmin.schema('public').from('group_members').select('group_id, user_id').in('group_id', groupIds),
-          ]);
-
-          const memberIds = [...new Set((membershipsWithUsers ?? []).map((membership) => membership.user_id))];
-          const { data: memberProfiles } =
-            memberIds.length > 0
-              ? await supabaseAdmin
-                  .schema('public')
-                  .from('users')
-                  .select('id, display_name, email, avatar_url')
-                  .in('id', memberIds)
-              : { data: [] };
-
-          const memberProfileById = new Map((memberProfiles ?? []).map((profile) => [profile.id, profile]));
-
-          return (groups ?? []).map((group) => {
-            const groupSchedules = (schedules ?? []).filter((schedule) => schedule.group_id === group.id);
-            const firstSchedule = groupSchedules[0];
-            const weeklyQuestions = groupSchedules.reduce((sum, schedule) => sum + (schedule.question_goal ?? 0), 0);
-            const groupMemberships = (membershipsWithUsers ?? []).filter((membership) => membership.group_id === group.id);
-            const membersPreview = (membershipsWithUsers ?? [])
-              .filter((membership) => membership.group_id === group.id)
-              .slice(0, 4)
-              .map((membership) => {
-                const profile = memberProfileById.get(membership.user_id);
-                const displayLabel = profile?.display_name ?? profile?.email ?? 'AB';
-                return {
-                  id: membership.user_id,
-                  initials: getInitials(displayLabel),
-                  avatarUrl: profile?.avatar_url ?? null,
-                };
-              });
-
-            return {
-              id: group.id,
-              name: group.name,
-              language: locale.toUpperCase(),
-              memberCount: groupMemberships.length,
-              scheduleLabel: firstSchedule
-                ? `${firstSchedule.start_time?.slice(0, 5) ?? '--:--'} - ${firstSchedule.end_time?.slice(0, 5) ?? '--:--'}`
-                : '',
-              weeklyQuestions,
-              membersPreview,
-            };
-          });
-        })()
-      : [];
-  const liveGroups =
-    canBrowseLookupLayer && primaryGroup
-      ? await (async () => {
-          const supabaseAdmin = createSupabaseAdminClient();
-          const { data: candidateGroups } = await supabaseAdmin
-            .schema('public')
-            .from('groups')
-            .select('id, name, invite_code, max_members, created_at')
-            .order('created_at', { ascending: false })
-            .limit(20);
-          const availableGroups = (candidateGroups ?? []).filter((group) => !currentGroupIds.has(group.id));
-          const availableGroupIds = availableGroups.map((group) => group.id);
-          if (availableGroupIds.length === 0) return [];
-
-          const [{ data: memberships }, { data: schedules }] = await Promise.all([
-            supabaseAdmin
-              .schema('public')
-              .from('group_members')
-              .select('group_id, user_id')
-              .in('group_id', availableGroupIds),
-            supabaseAdmin
-              .schema('public')
-              .from('group_weekly_schedules')
-              .select('group_id, question_goal')
-              .in('group_id', availableGroupIds),
-          ]);
-
-          const ids = [...new Set((memberships ?? []).map((membership) => membership.user_id))];
-          const { data: users } =
-            ids.length > 0
-              ? await supabaseAdmin.schema('public').from('users').select('id, display_name, email').in('id', ids)
-              : { data: [] };
-          const usersMap = new Map((users ?? []).map((profile) => [profile.id, profile]));
-
-          const membersByGroup = new Map<string, Array<{ user_id: string }>>();
-          for (const membership of memberships ?? []) {
-            const current = membersByGroup.get(membership.group_id) ?? [];
-            current.push({ user_id: membership.user_id });
-            membersByGroup.set(membership.group_id, current);
-          }
-
-          const weeklyByGroup = new Map<string, number>();
-          for (const schedule of schedules ?? []) {
-            weeklyByGroup.set(schedule.group_id, (weeklyByGroup.get(schedule.group_id) ?? 0) + schedule.question_goal);
-          }
-
-          return availableGroups
-            .map((group) => {
-              const members = membersByGroup.get(group.id) ?? [];
-              return {
-                id: group.id,
-                name: group.name,
-                inviteCode: group.invite_code,
-                memberCount: members.length,
-                maxMembers: group.max_members,
-                language: locale.toUpperCase(),
-                timezone: '',
-                weeklyQuestions: weeklyByGroup.get(group.id) ?? 0,
-                minutesAgo: Math.max(1, Math.round((Date.now() - new Date(group.created_at).getTime()) / 60000)),
-                compatible: true,
-                members: members.slice(0, 5).map((member) => {
-                  const profile = usersMap.get(member.user_id);
-                  const label = profile?.display_name ?? profile?.email ?? 'AB';
-                  return { id: member.user_id, initials: getInitials(label) };
-                }),
-              };
-            })
-            .filter((group) => group.memberCount < group.maxMembers);
-        })()
-      : [];
-
   return (
     <main className="flex flex-1 flex-col gap-5">
       {primaryGroup ? (
@@ -253,7 +109,7 @@ export default async function GroupRoutePage({
       <section className="mx-auto w-full max-w-[620px] space-y-4">
         <GroupPageView
           locale={locale}
-          shellGroups={shellGroups}
+          shellGroups={[]}
           currentUserInitials={getInitials(displayName)}
           canBrowseLookupLayer={canBrowseLookupLayer}
           initialLiveOpen={searchParams.live === '1'}
@@ -263,12 +119,12 @@ export default async function GroupRoutePage({
           schedules={data.weeklySchedules}
           weeklyCompletedQuestions={data.weeklyCompletedQuestions}
           weeklyTargetQuestions={data.weeklyTargetQuestions}
-          memberPerformance={data.memberPerformance}
+          memberPerformance={[]}
           weekdayLabels={weekdayLabels}
           groupInfoSummary={groupInfoSummary}
           sessions={data.sessions}
           canCreateSession={canCreateSession}
-          liveGroups={liveGroups}
+          liveGroups={[]}
           labels={{
             myGroups: t('myGroups'),
             activeGroup: t('activeGroup'),

--- a/app/[locale]/sessions/[sessionId]/page.tsx
+++ b/app/[locale]/sessions/[sessionId]/page.tsx
@@ -11,7 +11,7 @@ import type { AppLocale } from '@/i18n/routing';
 import { requireUser } from '@/lib/auth';
 import { getUserBillingSnapshot, TRIAL_QUESTION_LIMIT } from '@/lib/billing/user-tier';
 import type { ConfidenceLevel } from '@/lib/demo/confidence';
-import { getSessionData } from '@/lib/demo/data';
+import { getSessionPageData } from '@/lib/demo/data';
 import { ANSWER_OPTIONS } from '@/lib/types/demo';
 
 import {
@@ -32,6 +32,17 @@ type SessionPageProps = {
     q?: string;
     stage?: string;
   };
+};
+
+type ReviewQuestion = {
+  id: string;
+  body: string | null;
+  options: unknown;
+  order_index: number;
+  phase: string | null;
+  launched_at: string | null;
+  answer_deadline_at: string | null;
+  correct_option?: string | null;
 };
 
 function getDistribution(answers: Array<{ selected_option: string | null; confidence: string | null }>, memberCount: number) {
@@ -96,14 +107,18 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
   const locale = params.locale as AppLocale;
   const user = await requireUser(locale);
   const t = await getTranslations('Session');
-  const dashboardT = await getTranslations('Dashboard');
-  const [data, billingSnapshot] = await Promise.all([getSessionData(params.sessionId, user), getUserBillingSnapshot(user.id)]);
+  const data = await getSessionPageData(
+    params.sessionId,
+    user,
+    searchParams.stage,
+    Math.max(0, Number(searchParams.q ?? 0) || 0),
+  );
 
   if (!data?.session || !data.group) {
     notFound();
   }
 
-  const questionGoal = data.session.question_goal ?? Math.max(data.questions.length, 10);
+  const questionGoal = data.questionGoal;
   const currentIndex = Math.max(0, Math.min(Number(searchParams.q ?? 0) || 0, questionGoal - 1));
   const questions = [...data.questions].sort((left, right) => left.order_index - right.order_index);
   const question = questions.find((item) => item.order_index === currentIndex) ?? questions[currentIndex] ?? questions[0] ?? null;
@@ -113,16 +128,8 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
     ...(question ? [{ table: 'answers', filter: `question_id=eq.${question.id}` }] : []),
     { table: 'question_classifications', filter: `session_id=eq.${params.sessionId}` },
   ];
-  const myAnswers = data.allAnswers.filter((answer) => answer.user_id === user.id);
-  const answeredCount = new Set(myAnswers.map((answer) => answer.question_id)).size;
+  const answeredCount = data.answeredCount;
   const memberCount = Math.max(data.members.length, 1);
-  const trialProgress = {
-    current: Math.min(billingSnapshot?.questions_answered ?? 0, TRIAL_QUESTION_LIMIT),
-    total: TRIAL_QUESTION_LIMIT,
-    remaining: Math.max(TRIAL_QUESTION_LIMIT - (billingSnapshot?.questions_answered ?? 0), 0),
-    showWarning: (billingSnapshot?.questions_answered ?? 0) >= 85 && (billingSnapshot?.questions_answered ?? 0) < TRIAL_QUESTION_LIMIT,
-    isComplete: (billingSnapshot?.questions_answered ?? 0) >= TRIAL_QUESTION_LIMIT,
-  };
   const shouldShowCompletion =
     searchParams.stage === 'complete' ||
     (data.session.status === 'completed' && searchParams.stage !== 'review') ||
@@ -194,10 +201,11 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
   }
 
   if (isReview && question) {
+    const reviewQuestion = question as ReviewQuestion;
     const questionAnswers = data.allAnswers.filter((answer) => answer.question_id === question.id);
     const distribution = getDistribution(questionAnswers, data.members.length);
     const myReviewAnswer = questionAnswers.find((answer) => answer.user_id === user.id) ?? null;
-    const canFinish = questions.filter((item) => item.correct_option).length >= questionGoal;
+    const canFinish = questions.filter((item) => (item as ReviewQuestion).correct_option).length >= questionGoal;
     const isLastQuestion = currentIndex >= questionGoal - 1;
 
     return (
@@ -237,8 +245,8 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
             <div className="mt-8 flex items-end justify-center gap-8">
               {[...ANSWER_OPTIONS, '?'].map((option) => (
                 <div key={option} className="flex min-w-7 flex-col items-center gap-1 text-center">
-                  <span className={question.correct_option === option ? 'text-sm font-extrabold text-brand' : 'text-sm font-bold text-slate-500'}>
-                    {option}{question.correct_option === option ? ' *' : ''}
+                  <span className={reviewQuestion.correct_option === option ? 'text-sm font-extrabold text-brand' : 'text-sm font-bold text-slate-500'}>
+                    {option}{reviewQuestion.correct_option === option ? ' *' : ''}
                   </span>
                   <span className="text-xs font-bold text-slate-600">{distribution.get(option) ?? 0}</span>
                 </div>
@@ -253,7 +261,7 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
                 questionIndex={currentIndex}
                 nextQuestionIndex={Math.min(questionGoal - 1, currentIndex + 1)}
                 isLastQuestion={isLastQuestion}
-                initialCorrectOption={question.correct_option as never}
+                initialCorrectOption={reviewQuestion.correct_option as never}
                 participantAnswer={myReviewAnswer?.selected_option}
                 participantConfidence={myReviewAnswer?.confidence as ConfidenceLevel | null | undefined}
                 labels={{
@@ -302,8 +310,17 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
     );
   }
 
-  const myAnswer = data.allAnswers.find((answer) => answer.question_id === question.id && answer.user_id === user.id) ?? null;
-  const questionAnswers = data.allAnswers.filter((answer) => answer.question_id === question.id);
+  const dashboardT = await getTranslations('Dashboard');
+  const billingSnapshot = await getUserBillingSnapshot(user.id);
+  const trialProgress = {
+    current: Math.min(billingSnapshot?.questions_answered ?? 0, TRIAL_QUESTION_LIMIT),
+    total: TRIAL_QUESTION_LIMIT,
+    remaining: Math.max(TRIAL_QUESTION_LIMIT - (billingSnapshot?.questions_answered ?? 0), 0),
+    showWarning: (billingSnapshot?.questions_answered ?? 0) >= 85 && (billingSnapshot?.questions_answered ?? 0) < TRIAL_QUESTION_LIMIT,
+    isComplete: (billingSnapshot?.questions_answered ?? 0) >= TRIAL_QUESTION_LIMIT,
+  };
+  const myAnswer = data.currentQuestionAnswers.find((answer) => answer.user_id === user.id) ?? null;
+  const questionAnswers = data.currentQuestionAnswers;
   const isQuestionExpired =
     Boolean(question.answer_deadline_at) && new Date(question.answer_deadline_at ?? '').getTime() <= Date.now();
   const submittedCount = isQuestionExpired ? memberCount : questionAnswers.length;
@@ -354,7 +371,7 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
           questionId={question.id}
           questionIndex={currentIndex}
           initialAnswer={myAnswer?.selected_option}
-          initialConfidence={myAnswer?.confidence}
+          initialConfidence={myAnswer?.confidence as ConfidenceLevel | null | undefined}
           answerDeadlineAt={question.answer_deadline_at}
           submittedCount={submittedCount}
           memberCount={memberCount}

--- a/app/[locale]/sessions/[sessionId]/page.tsx
+++ b/app/[locale]/sessions/[sessionId]/page.tsx
@@ -9,7 +9,7 @@ import { SubmitButton } from '@/components/ui/submit-button';
 import { Link } from '@/i18n/navigation';
 import type { AppLocale } from '@/i18n/routing';
 import { requireUser } from '@/lib/auth';
-import { getUserBillingSnapshot, TRIAL_QUESTION_LIMIT } from '@/lib/billing/user-tier';
+import { getTrialProgressSnapshot, getUserBillingSnapshot } from '@/lib/billing/user-tier';
 import type { ConfidenceLevel } from '@/lib/demo/confidence';
 import { getSessionPageData } from '@/lib/demo/data';
 import { ANSWER_OPTIONS } from '@/lib/types/demo';
@@ -310,13 +310,7 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
 
   const dashboardT = await getTranslations('Dashboard');
   const billingSnapshot = await getUserBillingSnapshot(user.id);
-  const trialProgress = {
-    current: Math.min(billingSnapshot?.questions_answered ?? 0, TRIAL_QUESTION_LIMIT),
-    total: TRIAL_QUESTION_LIMIT,
-    remaining: Math.max(TRIAL_QUESTION_LIMIT - (billingSnapshot?.questions_answered ?? 0), 0),
-    showWarning: (billingSnapshot?.questions_answered ?? 0) >= 85 && (billingSnapshot?.questions_answered ?? 0) < TRIAL_QUESTION_LIMIT,
-    isComplete: (billingSnapshot?.questions_answered ?? 0) >= TRIAL_QUESTION_LIMIT,
-  };
+  const trialProgress = getTrialProgressSnapshot(billingSnapshot?.questions_answered ?? 0);
   const myAnswer = data.currentQuestionAnswers.find((answer) => answer.user_id === user.id) ?? null;
   const questionAnswers = data.currentQuestionAnswers;
   const isQuestionExpired =

--- a/app/api/groups/member-performance/route.ts
+++ b/app/api/groups/member-performance/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+
+import { getGroupMemberPerformance } from '@/lib/groups/server';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+export async function GET(request: Request) {
+  const groupId = new URL(request.url).searchParams.get('groupId');
+  if (!groupId) {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
+
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ ok: false }, { status: 401 });
+  }
+
+  const { data: membership } = await supabase
+    .schema('public')
+    .from('group_members')
+    .select('group_id')
+    .eq('group_id', groupId)
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (!membership) {
+    return NextResponse.json({ ok: false }, { status: 403 });
+  }
+
+  const members = await getGroupMemberPerformance(groupId, user.email ?? '');
+  return NextResponse.json({ ok: true, members });
+}

--- a/app/api/groups/shell/route.ts
+++ b/app/api/groups/shell/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+
+import { getShellGroupsForUser } from '@/lib/groups/server';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+export async function GET(request: Request) {
+  const locale = new URL(request.url).searchParams.get('locale') === 'fr' ? 'fr' : 'en';
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ ok: false }, { status: 401 });
+  }
+
+  const groups = await getShellGroupsForUser(user.id, locale);
+  return NextResponse.json({ ok: true, groups });
+}

--- a/app/api/live-groups/route.ts
+++ b/app/api/live-groups/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+
+import { getUserAccessState, hasUserTierCapability } from '@/lib/billing/gating';
+import { getLiveGroupsForUser } from '@/lib/groups/server';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+export async function GET(request: Request) {
+  const locale = new URL(request.url).searchParams.get('locale') === 'fr' ? 'fr' : 'en';
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ ok: false }, { status: 401 });
+  }
+
+  const accessState = await getUserAccessState(user.id);
+  if (!hasUserTierCapability(accessState, 'canBrowseLookupLayer')) {
+    return NextResponse.json({ ok: true, groups: [] });
+  }
+
+  const groups = await getLiveGroupsForUser(user.id, locale);
+  return NextResponse.json({ ok: true, groups });
+}

--- a/components/dashboard/live-groups-modal.tsx
+++ b/components/dashboard/live-groups-modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Lock } from 'lucide-react';
 
 import { Link, usePathname, useRouter } from '@/i18n/navigation';
@@ -86,8 +86,37 @@ function formatElapsedTime(minutes: number, labels: LiveGroupsModalProps['labels
 
 export function LiveGroupsModal({ locale, groups, canJoinLiveGroups, initialOpen = false, joinGroupAction, labels }: LiveGroupsModalProps) {
   const [open, setOpen] = useState(initialOpen);
+  const [resolvedGroups, setResolvedGroups] = useState(groups);
+  const [isLoading, setIsLoading] = useState(false);
   const pathname = usePathname();
   const router = useRouter();
+
+  useEffect(() => {
+    if (!open || resolvedGroups.length > 0) {
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+
+    fetch(`/api/live-groups?locale=${locale}`, { credentials: 'include' })
+      .then((response) => response.json())
+      .then((payload) => {
+        if (!cancelled && payload?.ok && Array.isArray(payload.groups)) {
+          setResolvedGroups(payload.groups);
+        }
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [locale, open, resolvedGroups.length]);
 
   function handleClose() {
     setOpen(false);
@@ -135,13 +164,19 @@ export function LiveGroupsModal({ locale, groups, canJoinLiveGroups, initialOpen
             </div>
 
             <div className="mt-5 space-y-3">
-              {groups.length === 0 ? (
+              {isLoading ? (
+                <div className="rounded-[12px] border border-white/[0.06] bg-[#18243a] p-4 text-sm font-semibold text-slate-400">
+                  Loading...
+                </div>
+              ) : null}
+
+              {!isLoading && resolvedGroups.length === 0 ? (
                 <div className="rounded-[12px] border border-white/[0.06] bg-[#18243a] p-4 text-sm font-semibold text-slate-400">
                   {labels.empty}
                 </div>
               ) : null}
 
-              {groups.map((group) => {
+              {resolvedGroups.map((group) => {
                 const remaining = Math.max(group.maxMembers - group.memberCount, 0);
 
                 return (

--- a/components/groups/group-page-view.tsx
+++ b/components/groups/group-page-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { AlertTriangle } from 'lucide-react';
 
 import { CreateSessionModal } from '@/components/sessions/create-session-modal';
@@ -205,13 +205,77 @@ export function GroupPageView({
   actions,
 }: GroupPageViewProps) {
   const [isCreateSessionOpen, setIsCreateSessionOpen] = useState(false);
+  const [resolvedShellGroups, setResolvedShellGroups] = useState(shellGroups);
+  const [resolvedMemberPerformance, setResolvedMemberPerformance] = useState(memberPerformance);
+  const [memberPerformanceLoaded, setMemberPerformanceLoaded] = useState(memberPerformance.length > 0);
   const groupPath = primaryGroup ? `/${locale}/groups/${primaryGroup.id}` : `/${locale}/groups`;
+  const sessionGroupChoices =
+    resolvedShellGroups.length > 0
+      ? resolvedShellGroups.map((group) => ({
+          id: group.id,
+          name: group.name,
+          memberCount: group.memberCount,
+        }))
+      : primaryGroup
+        ? [
+            {
+              id: primaryGroup.id,
+              name: primaryGroup.name,
+              memberCount: primaryGroup.memberCount,
+            },
+          ]
+        : [];
+
+  useEffect(() => {
+    if (resolvedShellGroups.length > 0) {
+      return;
+    }
+
+    let cancelled = false;
+    fetch(`/api/groups/shell?locale=${locale}`, { credentials: 'include' })
+      .then((response) => response.json())
+      .then((payload) => {
+        if (!cancelled && payload?.ok && Array.isArray(payload.groups)) {
+          setResolvedShellGroups(payload.groups);
+        }
+      })
+      .catch(() => undefined);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [locale, resolvedShellGroups.length]);
+
+  useEffect(() => {
+    if (!primaryGroup || memberPerformanceLoaded) {
+      return;
+    }
+
+    let cancelled = false;
+    fetch(`/api/groups/member-performance?groupId=${primaryGroup.id}`, { credentials: 'include' })
+      .then((response) => response.json())
+      .then((payload) => {
+        if (!cancelled && payload?.ok && Array.isArray(payload.members)) {
+          setResolvedMemberPerformance(payload.members);
+          setMemberPerformanceLoaded(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setMemberPerformanceLoaded(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [memberPerformanceLoaded, primaryGroup]);
 
   return (
     <>
-      {shellGroups.length > 0 ? (
+      {resolvedShellGroups.length > 0 ? (
         <GroupSwitcherMenu
-          groups={shellGroups}
+          groups={resolvedShellGroups}
           userInitials={currentUserInitials}
           labels={{
             myGroups: labels.myGroups,
@@ -428,8 +492,8 @@ export function GroupPageView({
         ) : null}
 
         <div className="mt-4 space-y-3">
-          {memberPerformance.length > 0 ? (
-            memberPerformance.map((member) => (
+          {resolvedMemberPerformance.length > 0 ? (
+            resolvedMemberPerformance.map((member) => (
               <div key={member.userId} className="rounded-[12px] bg-white/[0.04] px-3 py-3">
                 <div className="overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                   <div className="flex min-w-max items-center justify-between gap-4 whitespace-nowrap">
@@ -464,8 +528,14 @@ export function GroupPageView({
                 </div>
               </div>
             ))
-          ) : (
+          ) : memberPerformanceLoaded ? (
             <p className="text-sm text-slate-400">{labels.groupViewEmpty}</p>
+          ) : (
+            <div className="space-y-3">
+              {[0, 1, 2].map((item) => (
+                <div key={item} className="h-[72px] animate-pulse rounded-[12px] bg-white/[0.04]" />
+              ))}
+            </div>
           )}
         </div>
       </section>
@@ -473,11 +543,7 @@ export function GroupPageView({
       {isCreateSessionOpen && primaryGroup ? (
         <CreateSessionModal
           locale={locale}
-          groups={shellGroups.map((group) => ({
-            id: group.id,
-            name: group.name,
-            memberCount: group.memberCount,
-          }))}
+          groups={sessionGroupChoices}
           initialGroupId={primaryGroup.id}
           canCreateSession={canCreateSession}
           action={actions.createSessionAction}

--- a/lib/billing/user-tier.ts
+++ b/lib/billing/user-tier.ts
@@ -11,6 +11,7 @@ export const USER_TIERS = {
 } as const;
 
 export const TRIAL_QUESTION_LIMIT = 100;
+export const TRIAL_WARNING_THRESHOLD = 85;
 
 export const SUBSCRIPTION_STATUSES = {
   none: 'none',
@@ -40,6 +41,15 @@ type BillingSnapshot = Pick<
   | 'stripe_default_payment_method_id'
   | 'billing_updated_at'
 >;
+
+export type TrialProgressSnapshot = {
+  current: number;
+  total: number;
+  remaining: number;
+  warningThreshold: number;
+  showWarning: boolean;
+  isComplete: boolean;
+};
 
 export function deriveUserTier({
   questionsAnswered,
@@ -82,6 +92,17 @@ export function getUserTierCapabilities(userTier: UserTier) {
     canBeDiscoverable: canUseLookupLayer,
     canViewLiveSessionLinelist: canUseLookupLayer,
     canSendLookupInvites: canUseLookupLayer,
+  };
+}
+
+export function getTrialProgressSnapshot(questionsAnswered: number): TrialProgressSnapshot {
+  return {
+    current: Math.min(questionsAnswered, TRIAL_QUESTION_LIMIT),
+    total: TRIAL_QUESTION_LIMIT,
+    remaining: Math.max(TRIAL_QUESTION_LIMIT - questionsAnswered, 0),
+    warningThreshold: TRIAL_WARNING_THRESHOLD,
+    showWarning: questionsAnswered >= TRIAL_WARNING_THRESHOLD && questionsAnswered < TRIAL_QUESTION_LIMIT,
+    isComplete: questionsAnswered >= TRIAL_QUESTION_LIMIT,
   };
 }
 

--- a/lib/demo/data.ts
+++ b/lib/demo/data.ts
@@ -1000,6 +1000,217 @@ export const getGroupData = cache(async (groupId: string, user: User) => {
   };
 });
 
+async function getSessionShellData(sessionId: string, user: User) {
+  const supabase = createSupabaseServerClient();
+
+  const { data: session } = await supabase
+    .schema('public')
+    .from('sessions')
+    .select(
+      'id, group_id, name, scheduled_at, share_code, started_at, ended_at, timer_mode, timer_seconds, status, meeting_link, leader_id, question_goal',
+    )
+    .eq('id', sessionId)
+    .single();
+
+  if (!session) {
+    return null;
+  }
+
+  const { data: membership } = await supabase
+    .schema('public')
+    .from('group_members')
+    .select('group_id, is_founder')
+    .eq('group_id', session.group_id)
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (!membership) {
+    return null;
+  }
+
+  const [{ data: group }, { data: members }] = await Promise.all([
+    supabase.schema('public').from('groups').select('id, name, invite_code').eq('id', session.group_id).single(),
+    supabase.schema('public').from('group_members').select('user_id, is_founder').eq('group_id', session.group_id),
+  ]);
+
+  return {
+    supabase,
+    session,
+    group,
+    membership,
+    members: members ?? [],
+  };
+}
+
+export const getSessionPageData = cache(
+  async (sessionId: string, user: User, stage: string | undefined, questionIndex: number) => {
+    const shell = await getSessionShellData(sessionId, user);
+
+    if (!shell?.group) {
+      return null;
+    }
+
+    const { supabase, session, group, membership, members } = shell;
+    const answeredCountPromise = supabase
+      .schema('public')
+      .from('dashboard_user_session_answer_counts')
+      .select('answered_question_count')
+      .eq('user_id', user.id)
+      .eq('session_id', sessionId)
+      .maybeSingle();
+    const normalizedStage = stage === 'review' ? 'review' : 'answer';
+
+    if (session.status === 'scheduled') {
+      return {
+        session,
+        group,
+        membership,
+        members,
+        answeredCount: 0,
+        questionGoal: session.question_goal ?? 10,
+        questions: [] as Array<{
+          id: string;
+          body: string | null;
+          options: unknown;
+          order_index: number;
+          phase: string | null;
+          launched_at: string | null;
+          answer_deadline_at: string | null;
+          correct_option?: string | null;
+        }>,
+        currentQuestion: null,
+        currentQuestionAnswers: [] as Array<{
+          id: string;
+          user_id: string;
+          selected_option: string | null;
+          confidence: string | null;
+          is_correct: boolean | null;
+          answered_at: string | null;
+        }>,
+        allAnswers: [] as Array<{
+          id: string;
+          question_id: string;
+          user_id: string;
+          selected_option: string | null;
+          confidence: string | null;
+          is_correct: boolean | null;
+          answered_at: string | null;
+        }>,
+      };
+    }
+
+    if (normalizedStage === 'review') {
+      const [{ data: questions }, answeredCountResult] = await Promise.all([
+        supabase
+          .schema('public')
+          .from('questions')
+          .select('id, body, options, order_index, phase, launched_at, answer_deadline_at, correct_option, asked_by')
+          .eq('session_id', sessionId)
+          .order('order_index', { ascending: true }),
+        answeredCountPromise,
+      ]);
+
+      const safeQuestions = questions ?? [];
+      const safeQuestionIds = safeQuestions.map((question) => question.id);
+      const safeAllAnswers =
+        safeQuestionIds.length > 0
+          ? (
+              await supabase
+                .schema('public')
+                .from('answers')
+                .select('id, question_id, user_id, selected_option, confidence, is_correct, answered_at')
+                .in('question_id', safeQuestionIds)
+            ).data ?? []
+          : [];
+
+      return {
+        session,
+        group,
+        membership,
+        members,
+        answeredCount: answeredCountResult.data?.answered_question_count ?? 0,
+        questionGoal: session.question_goal ?? Math.max(safeQuestions.length, 10),
+        questions: safeQuestions,
+        currentQuestion: null,
+        currentQuestionAnswers: [] as Array<{
+          id: string;
+          user_id: string;
+          selected_option: string | null;
+          confidence: string | null;
+          is_correct: boolean | null;
+          answered_at: string | null;
+        }>,
+        allAnswers: safeAllAnswers,
+      };
+    }
+
+    const normalizedIndex = Number.isFinite(questionIndex) ? Math.max(0, questionIndex) : 0;
+    let currentQuestion =
+      (
+        await supabase
+          .schema('public')
+          .from('questions')
+          .select('id, body, options, order_index, phase, launched_at, answer_deadline_at')
+          .eq('session_id', sessionId)
+          .eq('order_index', normalizedIndex)
+          .maybeSingle()
+      ).data ?? null;
+
+    if (!currentQuestion) {
+      currentQuestion =
+        (
+          await supabase
+            .schema('public')
+            .from('questions')
+            .select('id, body, options, order_index, phase, launched_at, answer_deadline_at')
+            .eq('session_id', sessionId)
+            .order('order_index', { ascending: true })
+            .limit(1)
+            .maybeSingle()
+        ).data ?? null;
+    }
+
+    const [questionAnswersResult, answeredCountResult] = await Promise.all([
+      currentQuestion
+        ? supabase
+            .schema('public')
+            .from('answers')
+            .select('id, user_id, selected_option, confidence, is_correct, answered_at')
+            .eq('question_id', currentQuestion.id)
+        : Promise.resolve({ data: [] as Array<{
+            id: string;
+            user_id: string;
+            selected_option: string | null;
+            confidence: string | null;
+            is_correct: boolean | null;
+            answered_at: string | null;
+          }> }),
+      answeredCountPromise,
+    ]);
+
+    return {
+      session,
+      group,
+      membership,
+      members,
+      answeredCount: answeredCountResult.data?.answered_question_count ?? 0,
+      questionGoal: session.question_goal ?? Math.max((currentQuestion?.order_index ?? 0) + 1, 10),
+      questions: currentQuestion ? [currentQuestion] : [],
+      currentQuestion,
+      currentQuestionAnswers: questionAnswersResult.data ?? [],
+      allAnswers: [] as Array<{
+        id: string;
+        question_id: string;
+        user_id: string;
+        selected_option: string | null;
+        confidence: string | null;
+        is_correct: boolean | null;
+        answered_at: string | null;
+      }>,
+    };
+  },
+);
+
 export const getSessionData = cache(async (sessionId: string, user: User) => {
   const supabase = createSupabaseServerClient();
 

--- a/lib/demo/data.ts
+++ b/lib/demo/data.ts
@@ -807,6 +807,124 @@ export const getDashboardData = cache(
   },
 );
 
+export const getGroupCoreData = cache(async (groupId: string, user: User) => {
+  const perf = createPerfTracker(`getGroupCoreData:${groupId}`);
+  const supabase = createSupabaseServerClient();
+
+  const { data: membership } = await supabase
+    .schema('public')
+    .from('group_members')
+    .select('group_id, is_founder')
+    .eq('group_id', groupId)
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (!membership) {
+    return null;
+  }
+
+  const [{ data: group }, { data: members }, { data: sessions }, { data: weeklySchedules }] = await Promise.all([
+    supabase
+      .schema('public')
+      .from('groups')
+      .select('id, name, invite_code, created_by, created_at, meeting_link, max_members')
+      .eq('id', groupId)
+      .single(),
+    supabase.schema('public').from('group_members').select('user_id, is_founder').eq('group_id', groupId),
+    supabase
+      .schema('public')
+      .from('sessions')
+      .select('id, name, scheduled_at, share_code, status, timer_mode, timer_seconds, leader_id, meeting_link')
+      .eq('group_id', groupId)
+      .order('scheduled_at', { ascending: false }),
+    supabase
+      .schema('public')
+      .from('group_weekly_schedules')
+      .select('id, weekday, start_time, end_time, question_goal')
+      .eq('group_id', groupId)
+      .order('weekday', { ascending: true })
+      .order('start_time', { ascending: true }),
+  ]);
+
+  const safeMembers = members ?? [];
+  const safeSessions = sessions ?? [];
+  const safeWeeklySchedules = sortWeeklySchedules(weeklySchedules ?? []);
+  const sessionIds = safeSessions.map((session) => session.id);
+  const currentWeekStart = new Date();
+  const currentDay = currentWeekStart.getDay();
+  const offsetToMonday = currentDay === 0 ? 6 : currentDay - 1;
+  currentWeekStart.setDate(currentWeekStart.getDate() - offsetToMonday);
+  currentWeekStart.setHours(0, 0, 0, 0);
+
+  const weeklySessions = safeSessions.filter((session) => {
+    if (session.status === 'cancelled') return false;
+    return new Date(session.scheduled_at).getTime() >= currentWeekStart.getTime();
+  });
+  const weeklySessionIds = new Set(weeklySessions.map((session) => session.id));
+
+  const { data: groupQuestions } =
+    sessionIds.length > 0
+      ? await supabase.schema('public').from('questions').select('id, session_id').in('session_id', sessionIds)
+      : { data: [] as { id: string; session_id: string }[] };
+  const weeklyQuestionIds = new Set(
+    (groupQuestions ?? [])
+      .filter((question) => weeklySessionIds.has(question.session_id))
+      .map((question) => question.id),
+  );
+
+  const { data: weeklyAnswers } =
+    weeklyQuestionIds.size > 0
+      ? await supabase
+          .schema('public')
+          .from('answers')
+          .select('question_id')
+          .in('question_id', [...weeklyQuestionIds])
+      : { data: [] as { question_id: string }[] };
+
+  const questionAnswerCounts = new Map<string, number>();
+  for (const answer of weeklyAnswers ?? []) {
+    questionAnswerCounts.set(answer.question_id, (questionAnswerCounts.get(answer.question_id) ?? 0) + 1);
+  }
+
+  const weeklyTargetQuestions = safeWeeklySchedules.reduce((sum, schedule) => sum + schedule.question_goal, 0);
+  const qualifyingGroupSize = safeMembers.length >= 2 && safeMembers.length <= 5;
+  const weeklyCompletedQuestions = qualifyingGroupSize
+    ? (groupQuestions ?? []).filter(
+        (question) => weeklyQuestionIds.has(question.id) && (questionAnswerCounts.get(question.id) ?? 0) >= safeMembers.length,
+      ).length
+    : 0;
+
+  const founderCaptainId = safeMembers.find((member) => member.is_founder)?.user_id ?? null;
+  const sessionLeaderId =
+    safeSessions.find((session) => session.status === 'active')?.leader_id ??
+    safeSessions.find((session) => session.status === 'scheduled')?.leader_id ??
+    null;
+
+  perf.done({
+    members: safeMembers.length,
+    sessions: safeSessions.length,
+    weeklySchedules: safeWeeklySchedules.length,
+  });
+
+  return {
+    group: group
+      ? {
+          ...group,
+          is_founder: membership.is_founder,
+          memberCount: safeMembers.length,
+        }
+      : null,
+    membership,
+    sessions: safeSessions,
+    weeklySchedules: safeWeeklySchedules,
+    weeklyCompletedQuestions,
+    weeklyTargetQuestions,
+    weeklyProgressPercentage:
+      weeklyTargetQuestions > 0 ? Math.min(100, Math.round((weeklyCompletedQuestions / weeklyTargetQuestions) * 100)) : 0,
+    currentCaptainId: founderCaptainId ?? sessionLeaderId ?? null,
+  };
+});
+
 export const getGroupData = cache(async (groupId: string, user: User) => {
   const perf = createPerfTracker(`getGroupData:${groupId}`);
   const supabase = createSupabaseServerClient();

--- a/lib/groups/server.ts
+++ b/lib/groups/server.ts
@@ -1,0 +1,241 @@
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+function getInitials(value: string) {
+  return (
+    value
+      .split(' ')
+      .map((part) => part[0])
+      .join('')
+      .slice(0, 2)
+      .toUpperCase() || 'AB'
+  );
+}
+
+export async function getShellGroupsForUser(userId: string, locale: string) {
+  const supabase = createSupabaseServerClient();
+  const supabaseAdmin = createSupabaseAdminClient();
+  const { data: memberships } = await supabase
+    .schema('public')
+    .from('group_members')
+    .select('group_id')
+    .eq('user_id', userId);
+
+  const groupIds = [...new Set((memberships ?? []).map((membership) => membership.group_id))];
+  if (groupIds.length === 0) {
+    return [];
+  }
+
+  const [{ data: groups }, { data: schedules }, { data: membershipsWithUsers }] = await Promise.all([
+    supabase
+      .schema('public')
+      .from('groups')
+      .select('id, name')
+      .in('id', groupIds)
+      .order('created_at', { ascending: false }),
+    supabase
+      .schema('public')
+      .from('group_weekly_schedules')
+      .select('group_id, start_time, end_time, question_goal')
+      .in('group_id', groupIds),
+    supabaseAdmin.schema('public').from('group_members').select('group_id, user_id').in('group_id', groupIds),
+  ]);
+
+  const memberIds = [...new Set((membershipsWithUsers ?? []).map((membership) => membership.user_id))];
+  const { data: memberProfiles } =
+    memberIds.length > 0
+      ? await supabaseAdmin
+          .schema('public')
+          .from('users')
+          .select('id, display_name, email, avatar_url')
+          .in('id', memberIds)
+      : { data: [] };
+  const memberProfileById = new Map((memberProfiles ?? []).map((profile) => [profile.id, profile]));
+
+  return (groups ?? []).map((group) => {
+    const groupSchedules = (schedules ?? []).filter((schedule) => schedule.group_id === group.id);
+    const firstSchedule = groupSchedules[0];
+    const weeklyQuestions = groupSchedules.reduce((sum, schedule) => sum + (schedule.question_goal ?? 0), 0);
+    const groupMemberships = (membershipsWithUsers ?? []).filter((membership) => membership.group_id === group.id);
+    const membersPreview = groupMemberships.slice(0, 4).map((membership) => {
+      const profile = memberProfileById.get(membership.user_id);
+      const displayLabel = profile?.display_name ?? profile?.email ?? 'AB';
+
+      return {
+        id: membership.user_id,
+        initials: getInitials(displayLabel),
+        avatarUrl: profile?.avatar_url ?? null,
+      };
+    });
+
+    return {
+      id: group.id,
+      name: group.name,
+      language: locale.toUpperCase(),
+      memberCount: groupMemberships.length,
+      scheduleLabel: firstSchedule
+        ? `${firstSchedule.start_time?.slice(0, 5) ?? '--:--'} - ${firstSchedule.end_time?.slice(0, 5) ?? '--:--'}`
+        : '',
+      weeklyQuestions,
+      membersPreview,
+    };
+  });
+}
+
+export async function getGroupMemberPerformance(groupId: string, fallbackEmail = '') {
+  const supabase = createSupabaseServerClient();
+  const supabaseAdmin = createSupabaseAdminClient();
+  const [{ data: members }, { data: sessions }] = await Promise.all([
+    supabase.schema('public').from('group_members').select('user_id, is_founder').eq('group_id', groupId),
+    supabase
+      .schema('public')
+      .from('sessions')
+      .select('id, scheduled_at, status')
+      .eq('group_id', groupId),
+  ]);
+
+  const safeMembers = members ?? [];
+  const safeSessions = sessions ?? [];
+  const sessionIds = safeSessions.map((session) => session.id);
+  const { data: groupQuestions } =
+    sessionIds.length > 0
+      ? await supabase.schema('public').from('questions').select('id, session_id').in('session_id', sessionIds)
+      : { data: [] as { id: string; session_id: string }[] };
+  const questionIds = (groupQuestions ?? []).map((question) => question.id);
+
+  const { data: groupAnswers } =
+    questionIds.length > 0
+      ? await supabase
+          .schema('public')
+          .from('answers')
+          .select('question_id, user_id')
+          .in('question_id', questionIds)
+      : { data: [] as { question_id: string; user_id: string }[] };
+
+  const memberIds = [...new Set(safeMembers.map((member) => member.user_id))];
+  const { data: memberProfiles } =
+    memberIds.length > 0
+      ? await supabaseAdmin
+          .schema('public')
+          .from('users')
+          .select('id, display_name, email')
+          .in('id', memberIds)
+      : { data: [] };
+  const usersMap = new Map((memberProfiles ?? []).map((profile) => [profile.id, profile]));
+
+  const questionSessionById = new Map((groupQuestions ?? []).map((question) => [question.id, question.session_id]));
+  const answersByUser = new Map<string, { questionIds: Set<string>; sessionIds: Set<string> }>();
+  for (const answer of groupAnswers ?? []) {
+    const current = answersByUser.get(answer.user_id) ?? { questionIds: new Set<string>(), sessionIds: new Set<string>() };
+    current.questionIds.add(answer.question_id);
+    const sessionId = questionSessionById.get(answer.question_id);
+    if (sessionId) current.sessionIds.add(sessionId);
+    answersByUser.set(answer.user_id, current);
+  }
+
+  const sessionsById = new Map(safeSessions.map((session) => [session.id, session]));
+  const totalTrackableSessions = safeSessions.filter((session) => session.status !== 'cancelled').length;
+  const totalTrackableQuestions = questionIds.length;
+
+  return safeMembers.map((member) => {
+    const profile = usersMap.get(member.user_id);
+    const name = profile?.display_name ?? profile?.email ?? fallbackEmail ?? 'Member';
+    const answerStats = answersByUser.get(member.user_id);
+    const totalAnswers = answerStats?.questionIds.size ?? 0;
+    const activeWeekKeys = new Set(
+      [...(answerStats?.sessionIds ?? [])].map((sessionId) => {
+        const scheduledAt = sessionsById.get(sessionId)?.scheduled_at;
+        return scheduledAt ? scheduledAt.slice(0, 10) : sessionId;
+      }),
+    );
+
+    return {
+      userId: member.user_id,
+      name,
+      email: profile?.email ?? '',
+      initials: getInitials(name),
+      presenceRate: totalTrackableSessions > 0 ? Math.round(((answerStats?.sessionIds.size ?? 0) / totalTrackableSessions) * 100) : 0,
+      completionRate: totalTrackableQuestions > 0 ? Math.round(((answerStats?.questionIds.size ?? 0) / totalTrackableQuestions) * 100) : 0,
+      averageWeeklyQuestions: Math.round(totalAnswers / Math.max(1, activeWeekKeys.size)),
+      totalAnswers,
+      status: ((answerStats?.sessionIds.size ?? 0) === 0 && (answerStats?.questionIds.size ?? 0) === 0 ? 'setup' : 'active') as
+        | 'setup'
+        | 'active',
+    };
+  });
+}
+
+export async function getLiveGroupsForUser(userId: string, locale: string) {
+  const supabase = createSupabaseServerClient();
+  const supabaseAdmin = createSupabaseAdminClient();
+  const { data: memberships } = await supabase.schema('public').from('group_members').select('group_id').eq('user_id', userId);
+  const currentGroupIds = new Set((memberships ?? []).map((membership) => membership.group_id));
+
+  const { data: candidateGroups } = await supabaseAdmin
+    .schema('public')
+    .from('groups')
+    .select('id, name, invite_code, max_members, created_at')
+    .order('created_at', { ascending: false })
+    .limit(20);
+
+  const availableGroups = (candidateGroups ?? []).filter((group) => !currentGroupIds.has(group.id));
+  const availableGroupIds = availableGroups.map((group) => group.id);
+  if (availableGroupIds.length === 0) {
+    return [];
+  }
+
+  const [{ data: memberRows }, { data: schedules }] = await Promise.all([
+    supabaseAdmin
+      .schema('public')
+      .from('group_members')
+      .select('group_id, user_id')
+      .in('group_id', availableGroupIds),
+    supabaseAdmin
+      .schema('public')
+      .from('group_weekly_schedules')
+      .select('group_id, question_goal')
+      .in('group_id', availableGroupIds),
+  ]);
+
+  const memberIds = [...new Set((memberRows ?? []).map((membership) => membership.user_id))];
+  const { data: users } =
+    memberIds.length > 0
+      ? await supabaseAdmin.schema('public').from('users').select('id, display_name, email').in('id', memberIds)
+      : { data: [] };
+  const usersMap = new Map((users ?? []).map((profile) => [profile.id, profile]));
+
+  const membersByGroup = new Map<string, Array<{ user_id: string }>>();
+  for (const membership of memberRows ?? []) {
+    const current = membersByGroup.get(membership.group_id) ?? [];
+    current.push({ user_id: membership.user_id });
+    membersByGroup.set(membership.group_id, current);
+  }
+
+  const weeklyByGroup = new Map<string, number>();
+  for (const schedule of schedules ?? []) {
+    weeklyByGroup.set(schedule.group_id, (weeklyByGroup.get(schedule.group_id) ?? 0) + schedule.question_goal);
+  }
+
+  return availableGroups
+    .map((group) => {
+      const members = membersByGroup.get(group.id) ?? [];
+      return {
+        id: group.id,
+        name: group.name,
+        inviteCode: group.invite_code,
+        memberCount: members.length,
+        maxMembers: group.max_members,
+        language: locale.toUpperCase(),
+        timezone: '',
+        weeklyQuestions: weeklyByGroup.get(group.id) ?? 0,
+        minutesAgo: Math.max(1, Math.round((Date.now() - new Date(group.created_at).getTime()) / 60000)),
+        compatible: true,
+        members: members.slice(0, 5).map((member) => {
+          const profile = usersMap.get(member.user_id);
+          const label = profile?.display_name ?? profile?.email ?? 'AB';
+          return { id: member.user_id, initials: getInitials(label) };
+        }),
+      };
+    })
+    .filter((group) => group.memberCount < group.maxMembers);
+}


### PR DESCRIPTION
## Summary

This PR addresses the remaining authenticated-route loading slowness by reducing critical-path server work and deferring secondary data that does not need to block first render.

The main improvements target:
- session room entry
- group page initial render
- dashboard route shaping

## What changed

### 1. Session room data loading was split by route state
The session page no longer loads the same heavy dataset for every state.

Instead:
- `scheduled` routes load only session shell data
- active answer routes load only the current question, current-question answers, and answered-count state
- review routes load only the question/answer data needed for review
- completion routes no longer pay for the full active/review payload

This removes a large amount of unnecessary per-request data from the session-room critical path.

### 2. Group page now defers secondary data
The `/groups/[id]` route no longer blocks initial render on:
- full shell group-switcher payload
- live-groups discovery payload
- member performance rollups

Those sections now hydrate after initial render through dedicated authenticated APIs:
- `GET /api/groups/shell`
- `GET /api/groups/member-performance`
- `GET /api/live-groups`

The page still renders the critical group/session/schedule information immediately.

### 3. Dashboard route loads less irrelevant data per view
The dashboard now avoids loading session-only gating/billing data when the user is on the Performance view.

This keeps route work more tightly bounded to the active tab.

## Ticket alignment

- [x] Core authenticated routes load and become interactive faster
- [x] Critical-path data is loaded before secondary/decorative data
- [x] Session room entry avoids unnecessary historical payloads
- [x] Group page defers non-critical data that does not need to block first paint
- [x] Route-level loading behavior is more predictable across authenticated views


