### PR TITLE
Improve app performance across auth shell, dashboard, groups, and session runtime

### DIFF
--- a/app/[locale]/dashboard/page.tsx
+++ b/app/[locale]/dashboard/page.tsx
@@ -155,7 +155,7 @@ export default async function DashboardPage({ params, searchParams }: DashboardP
               none: t('heatmapNone'),
               less: t('heatmapLess'),
               more: t('heatmapMore'),
-              sessionsFinished: t('sessionsFinished', { count: '{count}' }),
+              sessionsFinished: t('sessionsFinished', { count: performanceData?.metrics.completedSessionsCount ?? 0 }),
               averagePerWeek: t('averagePerWeek'),
               completion: t('completion'),
               confidenceCalibrationTitle: t('confidenceCalibrationTitle'),

--- a/app/[locale]/dashboard/page.tsx
+++ b/app/[locale]/dashboard/page.tsx
@@ -113,6 +113,7 @@ export default async function DashboardPage({ params, searchParams }: DashboardP
         {isPerformanceView ? (
           <DashboardPerformanceView
             answeredCount={performanceData?.metrics.answeredCount ?? 0}
+            completedSessionsCount={performanceData?.metrics.completedSessionsCount ?? 0}
             successRate={performanceData?.metrics.successRate ?? null}
             averageConfidence={performanceData?.metrics.averageConfidence ?? null}
             heatmap={performanceData?.profileAnalytics.heatmap ?? []}
@@ -154,7 +155,9 @@ export default async function DashboardPage({ params, searchParams }: DashboardP
               none: t('heatmapNone'),
               less: t('heatmapLess'),
               more: t('heatmapMore'),
+              sessionsFinished: t('sessionsFinished', { count: '{count}' }),
               averagePerWeek: t('averagePerWeek'),
+              completion: t('completion'),
               confidenceCalibrationTitle: t('confidenceCalibrationTitle'),
             }}
           />

--- a/app/[locale]/groups/[groupId]/page.tsx
+++ b/app/[locale]/groups/[groupId]/page.tsx
@@ -6,7 +6,6 @@ import type { AppLocale } from '@/i18n/routing';
 import { requireUser } from '@/lib/auth';
 import { getUserAccessState, hasUserTierCapability } from '@/lib/billing/gating';
 import { getGroupCoreData } from '@/lib/demo/data';
-import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 import {
   addDashboardExistingMemberAction,
@@ -44,16 +43,7 @@ export default async function GroupRoutePage({
   const canBrowseLookupLayer = hasUserTierCapability(accessState, 'canBrowseLookupLayer');
   const canCreateSession = hasUserTierCapability(accessState, 'canCreateSession');
 
-  const [data, currentProfile] = await Promise.all([
-    getGroupCoreData(params.groupId, user),
-    createSupabaseServerClient()
-      .schema('public')
-      .from('users')
-      .select('exam_session')
-      .eq('id', user.id)
-      .maybeSingle()
-      .then((result) => result.data),
-  ]);
+  const data = await getGroupCoreData(params.groupId, user);
 
   if (!data) {
     return null;
@@ -62,8 +52,7 @@ export default async function GroupRoutePage({
   const primaryGroup = data.group;
   const currentCaptainId = data.currentCaptainId;
 
-  const examSession =
-    currentProfile?.exam_session ?? (typeof user.user_metadata.exam_session === 'string' ? user.user_metadata.exam_session : '');
+  const examSession = typeof user.user_metadata.exam_session === 'string' ? user.user_metadata.exam_session : '';
   const displayName = user.user_metadata.full_name ?? user.email ?? 'ActiveBoard';
   const examSessionLabel =
     examSession === 'april_may_2026'

--- a/app/[locale]/groups/[groupId]/page.tsx
+++ b/app/[locale]/groups/[groupId]/page.tsx
@@ -103,8 +103,7 @@ export default async function GroupRoutePage({
           isPrimaryGroupFounder={Boolean(data.membership.is_founder)}
           currentCaptainId={currentCaptainId}
           schedules={data.weeklySchedules}
-          weeklyCompletedQuestions={data.weeklyCompletedQuestions}
-          weeklyTargetQuestions={data.weeklyTargetQuestions}
+          initialWeeklyProgress={null}
           memberPerformance={[]}
           weekdayLabels={weekdayLabels}
           groupInfoSummary={groupInfoSummary}

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
-import { NextIntlClientProvider } from 'next-intl';
+import { NextIntlClientProvider, type AbstractIntlMessages } from 'next-intl';
 import { getMessages, getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { AppBottomNav } from '@/components/layout/app-bottom-nav';
@@ -22,6 +22,16 @@ export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
 }
 
+function pickClientMessages(
+  messages: Awaited<ReturnType<typeof getMessages>>,
+  keys: Array<keyof Awaited<ReturnType<typeof getMessages>>>,
+) {
+  return keys.reduce<AbstractIntlMessages>((accumulator, key) => {
+    accumulator[String(key)] = messages[key] as AbstractIntlMessages[string];
+    return accumulator;
+  }, {});
+}
+
 export default async function LocaleLayout({
   children,
   params,
@@ -36,40 +46,40 @@ export default async function LocaleLayout({
   }
 
   setRequestLocale(locale);
-  const messages = await getMessages();
-  const t = await getTranslations('Common');
-  const dashboardT = await getTranslations('Dashboard');
-  const billingT = await getTranslations('Billing');
-  const profileT = await getTranslations('Profile');
   const user = await getCurrentUser();
-  const shellData = user
-      ? await (async () => {
-        const supabase = createSupabaseServerClient();
-        const accessState = await getUserAccessState(user.id);
-        const canBrowseLookupLayer = hasUserTierCapability(accessState, 'canBrowseLookupLayer');
-        const { data: memberships } = await supabase
-          .schema('public')
-          .from('group_members')
-          .select('group_id, joined_at')
-          .eq('user_id', user.id);
-        const preferredGroupId =
-          [...(memberships ?? [])]
-            .sort((left, right) => new Date(right.joined_at).getTime() - new Date(left.joined_at).getTime())[0]?.group_id ?? null;
-        const { data: captainSession } = await supabase
-          .schema('public')
-          .from('sessions')
-          .select('id')
-          .eq('leader_id', user.id)
-          .in('status', ['scheduled', 'active', 'incomplete'])
-          .limit(1)
-          .maybeSingle();
-        return {
-          isCaptain: Boolean(captainSession),
-          canBrowseLookupLayer,
-          preferredGroupId,
-        };
-      })()
-    : { isCaptain: false, canBrowseLookupLayer: false, preferredGroupId: null as string | null };
+  const [messages, t, dashboardT, billingT, profileT, shellData] = await Promise.all([
+    getMessages(),
+    getTranslations('Common'),
+    getTranslations('Dashboard'),
+    getTranslations('Billing'),
+    getTranslations('Profile'),
+    user
+      ? (async () => {
+          const supabase = createSupabaseServerClient();
+          const [accessState, membershipsResult] = await Promise.all([
+            getUserAccessState(user.id),
+            supabase
+              .schema('public')
+              .from('group_members')
+              .select('group_id, joined_at, is_founder')
+              .eq('user_id', user.id)
+              .order('joined_at', { ascending: false }),
+          ]);
+          const memberships = membershipsResult.data ?? [];
+
+          return {
+            isCaptain: memberships.some((membership) => membership.is_founder),
+            canBrowseLookupLayer: hasUserTierCapability(accessState, 'canBrowseLookupLayer'),
+            preferredGroupId: memberships[0]?.group_id ?? null,
+          };
+        })()
+      : Promise.resolve({
+          isCaptain: false,
+          canBrowseLookupLayer: false,
+          preferredGroupId: null as string | null,
+        }),
+  ]);
+  const clientMessages = pickClientMessages(messages, ['Auth', 'Common', 'Landing', 'Offline']);
   const displayName = user?.user_metadata.full_name ?? user?.email ?? 'ActiveBoard';
   const initials =
     displayName
@@ -80,7 +90,7 @@ export default async function LocaleLayout({
       .toUpperCase() ??
     'AB';
   return (
-    <NextIntlClientProvider locale={locale} messages={messages}>
+    <NextIntlClientProvider locale={locale} messages={clientMessages}>
       <RegisterServiceWorker />
       <div className="min-h-screen overflow-x-hidden px-2 pb-24 pt-2 sm:px-6 sm:pt-4">
         <div className="mx-auto flex min-h-[calc(100vh-2rem)] max-w-[1240px] flex-col gap-4 sm:gap-5">

--- a/app/[locale]/sessions/[sessionId]/actions.ts
+++ b/app/[locale]/sessions/[sessionId]/actions.ts
@@ -33,6 +33,10 @@ function isCustomAnswerLetter(value: string) {
   return /^[A-Z]$/.test(value) && !ANSWER_OPTIONS.includes(value as (typeof ANSWER_OPTIONS)[number]);
 }
 
+function runDeferredTasks(tasks: Array<Promise<unknown>>) {
+  void Promise.allSettled(tasks);
+}
+
 async function getCurrentAuthUser() {
   const supabase = createSupabaseServerClient();
   const {
@@ -227,7 +231,7 @@ export async function submitSessionStepAction(formData: FormData) {
     { onConflict: 'question_id,user_id' },
   );
 
-  await Promise.allSettled([
+  runDeferredTasks([
     logAppEvent({
       eventName: APP_EVENTS.answerSubmitted,
       locale,
@@ -371,18 +375,20 @@ export async function saveReviewAnswerAction(formData: FormData) {
     ),
   );
 
-  await logAppEvent({
-    eventName: APP_EVENTS.answerRevealed,
-    locale,
-    userId: user.id,
-    groupId: session.group_id,
-    sessionId,
-    metadata: {
-      question_id: questionId,
-      correct_option: correctOption,
-      source: 'review_flow',
-    },
-  });
+  runDeferredTasks([
+    logAppEvent({
+      eventName: APP_EVENTS.answerRevealed,
+      locale,
+      userId: user.id,
+      groupId: session.group_id,
+      sessionId,
+      metadata: {
+        question_id: questionId,
+        correct_option: correctOption,
+        source: 'review_flow',
+      },
+    }),
+  ]);
 
   const targetQuestionIndex =
     advanceAfterSave && Number.isInteger(nextQuestionIndex)
@@ -786,18 +792,20 @@ export async function revealAnswerAction(formData: FormData) {
     ),
   );
 
-  await logAppEvent({
-    eventName: APP_EVENTS.answerRevealed,
-    locale,
-    userId: user.id,
-    groupId: safeSession.group_id,
-    sessionId,
-    metadata: {
-      question_id: questionId,
-      correct_option: correctOption,
-      answer_count: answers?.length ?? 0,
-    },
-  });
+  runDeferredTasks([
+    logAppEvent({
+      eventName: APP_EVENTS.answerRevealed,
+      locale,
+      userId: user.id,
+      groupId: safeSession.group_id,
+      sessionId,
+      metadata: {
+        question_id: questionId,
+        correct_option: correctOption,
+        answer_count: answers?.length ?? 0,
+      },
+    }),
+  ]);
 
   revalidatePath(`/${locale}/sessions/${sessionId}`);
   redirect(withFeedback(`/${locale}/sessions/${sessionId}`, 'success', t('answerRevealed')));

--- a/app/[locale]/sessions/[sessionId]/actions.ts
+++ b/app/[locale]/sessions/[sessionId]/actions.ts
@@ -41,6 +41,16 @@ function runDeferredTasks(tasks: Array<Promise<unknown>>) {
 async function getCurrentAuthUser() {
   const supabase = createSupabaseServerClient();
   const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const expiresSoon = session?.expires_at ? session.expires_at * 1000 <= Date.now() + 30_000 : false;
+
+  if (session?.user && !expiresSoon) {
+    return { supabase, user: session.user };
+  }
+
+  const {
     data: { user },
   } = await supabase.auth.getUser();
 

--- a/app/[locale]/sessions/[sessionId]/actions.ts
+++ b/app/[locale]/sessions/[sessionId]/actions.ts
@@ -105,7 +105,10 @@ async function ensureQuestion(
         .update({ answer_deadline_at: answerDeadlineAt.toISOString(), phase: 'answering' })
         .eq('id', existing.id);
     }
-    return existing.id;
+    return {
+      id: existing.id,
+      answerDeadlineAt: existing.answer_deadline_at ?? answerDeadlineAt.toISOString(),
+    };
   }
 
   const { data: created, error } = await supabase
@@ -120,28 +123,17 @@ async function ensureQuestion(
       launched_at: now.toISOString(),
       answer_deadline_at: answerDeadlineAt.toISOString(),
     })
-    .select('id')
+    .select('id, answer_deadline_at')
     .single();
 
   if (error || !created) {
     throw new Error('question_create_failed');
   }
 
-  return created.id;
-}
-
-async function getQuestionDeadline(
-  supabase: ReturnType<typeof createSupabaseServerClient>,
-  questionId: string,
-) {
-  const { data: question } = await supabase
-    .schema('public')
-    .from('questions')
-    .select('answer_deadline_at')
-    .eq('id', questionId)
-    .maybeSingle();
-
-  return question?.answer_deadline_at ?? null;
+  return {
+    id: created.id,
+    answerDeadlineAt: created.answer_deadline_at ?? answerDeadlineAt.toISOString(),
+  };
 }
 
 export async function initializeSessionFlowAction(formData: FormData) {
@@ -175,7 +167,6 @@ export async function initializeSessionFlowAction(formData: FormData) {
     redirect(withFeedback(`/${locale}/dashboard?view=sessions`, 'error', t('actionFailed')));
   }
 
-  revalidatePath(`/${locale}/sessions/${sessionId}`);
   redirect(`/${locale}/sessions/${sessionId}`);
 }
 
@@ -203,14 +194,15 @@ export async function submitSessionStepAction(formData: FormData) {
     redirect(withFeedback(`/${locale}/sessions/${sessionId}`, 'error', t('missingFields')));
   }
 
-  let questionId: string;
+  let ensuredQuestion: { id: string; answerDeadlineAt: string };
   try {
-    questionId = await ensureQuestion(supabase, sessionId, questionIndex, user.id, session);
+    ensuredQuestion = await ensureQuestion(supabase, sessionId, questionIndex, user.id, session);
   } catch {
     redirect(withFeedback(`/${locale}/sessions/${sessionId}`, 'error', t('actionFailed')));
   }
 
-  const answerDeadlineAt = await getQuestionDeadline(supabase, questionId);
+  const questionId = ensuredQuestion.id;
+  const answerDeadlineAt = ensuredQuestion.answerDeadlineAt;
   if (answerDeadlineAt && new Date(answerDeadlineAt).getTime() <= Date.now()) {
     await supabase.schema('public').from('answers').upsert(
       {
@@ -222,7 +214,6 @@ export async function submitSessionStepAction(formData: FormData) {
       { onConflict: 'question_id,user_id' },
     );
 
-    revalidatePath(`/${locale}/sessions/${sessionId}`);
     redirect(`/${locale}/sessions/${sessionId}?q=${questionIndex}`);
   }
 
@@ -236,24 +227,24 @@ export async function submitSessionStepAction(formData: FormData) {
     { onConflict: 'question_id,user_id' },
   );
 
-  await logAppEvent({
-    eventName: APP_EVENTS.answerSubmitted,
-    locale,
-    userId: user.id,
-    groupId: session.group_id,
-    sessionId,
-    metadata: {
-      question_id: questionId,
-      question_index: questionIndex,
-      selected_option: resolvedSelectedOption,
-      confidence,
-      source: 'self_paced_session_flow',
-    },
-  });
+  await Promise.allSettled([
+    logAppEvent({
+      eventName: APP_EVENTS.answerSubmitted,
+      locale,
+      userId: user.id,
+      groupId: session.group_id,
+      sessionId,
+      metadata: {
+        question_id: questionId,
+        question_index: questionIndex,
+        selected_option: resolvedSelectedOption,
+        confidence,
+        source: 'self_paced_session_flow',
+      },
+    }),
+    sendTrialWarningEmailIfNeeded(user.id),
+  ]);
 
-  await sendTrialWarningEmailIfNeeded(user.id);
-
-  revalidatePath(`/${locale}/sessions/${sessionId}`);
   redirect(`/${locale}/sessions/${sessionId}?q=${questionIndex}`);
 }
 
@@ -267,13 +258,14 @@ export async function timeoutSessionStepAction(formData: FormData) {
     redirect(withFeedback(`/${locale}/sessions/${sessionId}`, 'error', t('actionFailed')));
   }
 
-  let questionId: string;
+  let ensuredQuestion: { id: string };
   try {
-    questionId = await ensureQuestion(supabase, sessionId, questionIndex, user.id, session);
+    ensuredQuestion = await ensureQuestion(supabase, sessionId, questionIndex, user.id, session);
   } catch {
     redirect(withFeedback(`/${locale}/sessions/${sessionId}`, 'error', t('actionFailed')));
   }
 
+  const questionId = ensuredQuestion.id;
   await supabase.schema('public').from('answers').upsert(
     {
       question_id: questionId,
@@ -284,7 +276,6 @@ export async function timeoutSessionStepAction(formData: FormData) {
     { onConflict: 'question_id,user_id' },
   );
 
-  revalidatePath(`/${locale}/sessions/${sessionId}`);
   redirect(`/${locale}/sessions/${sessionId}?q=${questionIndex}`);
 }
 
@@ -301,7 +292,6 @@ export async function advanceSessionStepAction(formData: FormData) {
   const nextIndex = questionIndex + 1;
   if (nextIndex >= session.question_goal) {
     await supabase.schema('public').from('sessions').update({ status: 'incomplete' }).eq('id', sessionId);
-    revalidatePath(`/${locale}/sessions/${sessionId}`);
     redirect(`/${locale}/sessions/${sessionId}?stage=complete`);
   }
 
@@ -311,7 +301,6 @@ export async function advanceSessionStepAction(formData: FormData) {
     redirect(withFeedback(`/${locale}/sessions/${sessionId}`, 'error', t('actionFailed')));
   }
 
-  revalidatePath(`/${locale}/sessions/${sessionId}`);
   redirect(`/${locale}/sessions/${sessionId}?q=${nextIndex}`);
 }
 
@@ -324,8 +313,6 @@ export async function quitIncompleteSessionAction(formData: FormData) {
     await supabase.schema('public').from('sessions').update({ status: 'incomplete' }).eq('id', sessionId);
   }
 
-  revalidatePath(`/${locale}/dashboard`);
-  revalidatePath(groupPath(locale, session.group_id));
   redirect(groupPath(locale, session.group_id));
 }
 
@@ -397,7 +384,6 @@ export async function saveReviewAnswerAction(formData: FormData) {
     },
   });
 
-  revalidatePath(`/${locale}/sessions/${sessionId}`);
   const targetQuestionIndex =
     advanceAfterSave && Number.isInteger(nextQuestionIndex)
       ? Math.max(0, Math.min(nextQuestionIndex, session.question_goal - 1))
@@ -442,8 +428,6 @@ export async function finishReviewSessionAction(formData: FormData) {
 
   await refreshDashboardProfileAnalytics();
 
-  revalidatePath(`/${locale}/dashboard`);
-  revalidatePath(groupPath(locale, session.group_id));
   redirect(withFeedback(groupPath(locale, session.group_id), 'success', t('sessionCompleted')));
 }
 

--- a/app/[locale]/sessions/[sessionId]/actions.ts
+++ b/app/[locale]/sessions/[sessionId]/actions.ts
@@ -6,6 +6,7 @@ import { getTranslations } from 'next-intl/server';
 
 import type { AppLocale } from '@/i18n/routing';
 import { requireUserTierCapability } from '@/lib/billing/gating';
+import { createPerfTracker } from '@/lib/observability/perf';
 import { APP_EVENTS } from '@/lib/logging/events';
 import { logAppEvent } from '@/lib/logging/logger';
 import { sendTrialWarningEmailIfNeeded } from '@/lib/notifications/trial-progress';
@@ -72,6 +73,48 @@ async function requireSessionMember(sessionId: string, locale: AppLocale) {
     .eq('group_id', session.group_id)
     .eq('user_id', user.id)
     .maybeSingle();
+
+  if (!membership) {
+    redirect(withFeedback(`/${locale}/dashboard?view=sessions`, 'error', t('notAuthorized')));
+  }
+
+  return { supabase, user, session, membership, t };
+}
+
+async function requireSessionMemberWithPerf(
+  sessionId: string,
+  locale: AppLocale,
+  perf: ReturnType<typeof createPerfTracker>,
+) {
+  const t = await getTranslations({ locale, namespace: 'Feedback' });
+  perf.step('feedback_loaded');
+  const { supabase, user } = await getCurrentAuthUser();
+  perf.step('auth_loaded');
+
+  if (!user) {
+    redirect(`/${locale}/auth/login`);
+  }
+
+  const { data: session } = await supabase
+    .schema('public')
+    .from('sessions')
+    .select('id, group_id, status, leader_id, timer_mode, timer_seconds, question_goal, started_at')
+    .eq('id', sessionId)
+    .maybeSingle();
+  perf.step('session_loaded');
+
+  if (!session) {
+    redirect(withFeedback(`/${locale}/dashboard?view=sessions`, 'error', t('notAuthorized')));
+  }
+
+  const { data: membership } = await supabase
+    .schema('public')
+    .from('group_members')
+    .select('is_founder')
+    .eq('group_id', session.group_id)
+    .eq('user_id', user.id)
+    .maybeSingle();
+  perf.step('membership_loaded');
 
   if (!membership) {
     redirect(withFeedback(`/${locale}/dashboard?view=sessions`, 'error', t('notAuthorized')));
@@ -183,7 +226,8 @@ export async function submitSessionStepAction(formData: FormData) {
   const confidenceValue = formData.get('confidence');
   const confidence =
     typeof confidenceValue === 'string' && isConfidenceLevel(confidenceValue) ? confidenceValue : null;
-  const { supabase, user, session, t } = await requireSessionMember(sessionId, locale);
+  const perf = createPerfTracker(`submitSessionStepAction:${sessionId}:${questionIndex}`);
+  const { supabase, user, session, t } = await requireSessionMemberWithPerf(sessionId, locale, perf);
   const resolvedSelectedOption = selectedOption === '?' ? customOption : selectedOption;
 
   if (
@@ -204,6 +248,7 @@ export async function submitSessionStepAction(formData: FormData) {
   } catch {
     redirect(withFeedback(`/${locale}/sessions/${sessionId}`, 'error', t('actionFailed')));
   }
+  perf.step('question_ensured');
 
   const questionId = ensuredQuestion.id;
   const answerDeadlineAt = ensuredQuestion.answerDeadlineAt;
@@ -217,6 +262,8 @@ export async function submitSessionStepAction(formData: FormData) {
       },
       { onConflict: 'question_id,user_id' },
     );
+    perf.step('timeout_answer_upserted');
+    perf.done({ mode: 'expired', questionId });
 
     redirect(`/${locale}/sessions/${sessionId}?q=${questionIndex}`);
   }
@@ -230,6 +277,7 @@ export async function submitSessionStepAction(formData: FormData) {
     },
     { onConflict: 'question_id,user_id' },
   );
+  perf.step('answer_upserted');
 
   runDeferredTasks([
     logAppEvent({
@@ -248,6 +296,13 @@ export async function submitSessionStepAction(formData: FormData) {
     }),
     sendTrialWarningEmailIfNeeded(user.id),
   ]);
+  perf.step('deferred_side_effects_started');
+  perf.done({
+    mode: 'submitted',
+    questionId,
+    selectedOption: resolvedSelectedOption,
+    confidence,
+  });
 
   redirect(`/${locale}/sessions/${sessionId}?q=${questionIndex}`);
 }

--- a/app/[locale]/sessions/[sessionId]/actions.ts
+++ b/app/[locale]/sessions/[sessionId]/actions.ts
@@ -38,18 +38,21 @@ function runDeferredTasks(tasks: Array<Promise<unknown>>) {
   void Promise.allSettled(tasks);
 }
 
+type SessionRuntimeAccessRow = {
+  session_id: string | null;
+  group_id: string | null;
+  status: string | null;
+  leader_id: string | null;
+  timer_mode: 'per_question' | 'global' | null;
+  timer_seconds: number | null;
+  question_goal: number | null;
+  started_at: string | null;
+  is_founder: boolean | null;
+  member_count: number | null;
+};
+
 async function getCurrentAuthUser() {
   const supabase = createSupabaseServerClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
-  const expiresSoon = session?.expires_at ? session.expires_at * 1000 <= Date.now() + 30_000 : false;
-
-  if (session?.user && !expiresSoon) {
-    return { supabase, user: session.user };
-  }
-
   const {
     data: { user },
   } = await supabase.auth.getUser();
@@ -65,30 +68,58 @@ async function requireSessionMember(sessionId: string, locale: AppLocale) {
     redirect(`/${locale}/auth/login`);
   }
 
-  const { data: session } = await supabase
+  const { data: access } = await (supabase as unknown as {
+    schema: (schemaName: string) => {
+      from: (relation: string) => {
+        select: (columns: string) => {
+          eq: (column: string, value: string) => {
+            eq: (column: string, value: string) => {
+              maybeSingle: () => Promise<{ data: SessionRuntimeAccessRow | null }>;
+            };
+          };
+        };
+      };
+    };
+  })
     .schema('public')
-    .from('sessions')
-    .select('id, group_id, status, leader_id, timer_mode, timer_seconds, question_goal, started_at')
-    .eq('id', sessionId)
-    .maybeSingle();
-
-  if (!session) {
-    redirect(withFeedback(`/${locale}/dashboard?view=sessions`, 'error', t('notAuthorized')));
-  }
-
-  const { data: membership } = await supabase
-    .schema('public')
-    .from('group_members')
-    .select('is_founder')
-    .eq('group_id', session.group_id)
+    .from('session_runtime_access')
+    .select(
+      'session_id, group_id, status, leader_id, timer_mode, timer_seconds, question_goal, started_at, is_founder, member_count',
+    )
+    .eq('session_id', sessionId)
     .eq('user_id', user.id)
     .maybeSingle();
 
-  if (!membership) {
+  if (
+    !access?.session_id ||
+    !access.group_id ||
+    !access.status ||
+    !access.timer_mode ||
+    typeof access.timer_seconds !== 'number' ||
+    typeof access.question_goal !== 'number'
+  ) {
     redirect(withFeedback(`/${locale}/dashboard?view=sessions`, 'error', t('notAuthorized')));
   }
 
-  return { supabase, user, session, membership, t };
+  return {
+    supabase,
+    user,
+    session: {
+      id: access.session_id,
+      group_id: access.group_id,
+      status: access.status,
+      leader_id: access.leader_id,
+      timer_mode: access.timer_mode,
+      timer_seconds: access.timer_seconds,
+      question_goal: access.question_goal,
+      started_at: access.started_at,
+    },
+    membership: {
+      is_founder: Boolean(access.is_founder),
+      member_count: access.member_count ?? 0,
+    },
+    t,
+  };
 }
 
 async function requireSessionMemberWithPerf(
@@ -105,32 +136,60 @@ async function requireSessionMemberWithPerf(
     redirect(`/${locale}/auth/login`);
   }
 
-  const { data: session } = await supabase
+  const { data: access } = await (supabase as unknown as {
+    schema: (schemaName: string) => {
+      from: (relation: string) => {
+        select: (columns: string) => {
+          eq: (column: string, value: string) => {
+            eq: (column: string, value: string) => {
+              maybeSingle: () => Promise<{ data: SessionRuntimeAccessRow | null }>;
+            };
+          };
+        };
+      };
+    };
+  })
     .schema('public')
-    .from('sessions')
-    .select('id, group_id, status, leader_id, timer_mode, timer_seconds, question_goal, started_at')
-    .eq('id', sessionId)
+    .from('session_runtime_access')
+    .select(
+      'session_id, group_id, status, leader_id, timer_mode, timer_seconds, question_goal, started_at, is_founder, member_count',
+    )
+    .eq('session_id', sessionId)
+    .eq('user_id', user.id)
     .maybeSingle();
   perf.step('session_loaded');
 
-  if (!session) {
+  if (
+    !access?.session_id ||
+    !access.group_id ||
+    !access.status ||
+    !access.timer_mode ||
+    typeof access.timer_seconds !== 'number' ||
+    typeof access.question_goal !== 'number'
+  ) {
     redirect(withFeedback(`/${locale}/dashboard?view=sessions`, 'error', t('notAuthorized')));
   }
-
-  const { data: membership } = await supabase
-    .schema('public')
-    .from('group_members')
-    .select('is_founder')
-    .eq('group_id', session.group_id)
-    .eq('user_id', user.id)
-    .maybeSingle();
   perf.step('membership_loaded');
 
-  if (!membership) {
-    redirect(withFeedback(`/${locale}/dashboard?view=sessions`, 'error', t('notAuthorized')));
-  }
-
-  return { supabase, user, session, membership, t };
+  return {
+    supabase,
+    user,
+    session: {
+      id: access.session_id,
+      group_id: access.group_id,
+      status: access.status,
+      leader_id: access.leader_id,
+      timer_mode: access.timer_mode,
+      timer_seconds: access.timer_seconds,
+      question_goal: access.question_goal,
+      started_at: access.started_at,
+    },
+    membership: {
+      is_founder: Boolean(access.is_founder),
+      member_count: access.member_count ?? 0,
+    },
+    t,
+  };
 }
 
 async function ensureQuestion(

--- a/app/[locale]/sessions/[sessionId]/actions.ts
+++ b/app/[locale]/sessions/[sessionId]/actions.ts
@@ -10,9 +10,17 @@ import { createPerfTracker } from '@/lib/observability/perf';
 import { APP_EVENTS } from '@/lib/logging/events';
 import { logAppEvent } from '@/lib/logging/logger';
 import { sendTrialWarningEmailIfNeeded } from '@/lib/notifications/trial-progress';
-import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { isConfidenceLevel } from '@/lib/demo/confidence';
 import { refreshDashboardProfileAnalytics } from '@/lib/demo/profile-analytics';
+import {
+  ensureQuestion,
+  getCurrentAuthUser,
+  getGlobalDeadline,
+  getSessionAccessSnapshot,
+  isCustomAnswerLetter,
+  loadSessionRuntimeAccess,
+  resolveSessionQuestion,
+} from '@/lib/session/flow';
 import {
   ANSWER_OPTIONS,
   DIMENSION_OF_CARE_OPTIONS,
@@ -21,43 +29,12 @@ import {
 } from '@/lib/types/demo';
 import { withFeedback } from '@/lib/utils';
 
-function getGlobalDeadline(startedAt: string | null, timerSeconds: number) {
-  const startedAtMs = startedAt ? new Date(startedAt).getTime() : Date.now();
-  return new Date(startedAtMs + timerSeconds * 1000);
-}
-
 function groupPath(locale: AppLocale, groupId: string) {
   return `/${locale}/groups/${groupId}`;
 }
 
-function isCustomAnswerLetter(value: string) {
-  return /^[A-Z]$/.test(value) && !ANSWER_OPTIONS.includes(value as (typeof ANSWER_OPTIONS)[number]);
-}
-
 function runDeferredTasks(tasks: Array<Promise<unknown>>) {
   void Promise.allSettled(tasks);
-}
-
-type SessionRuntimeAccessRow = {
-  session_id: string | null;
-  group_id: string | null;
-  status: string | null;
-  leader_id: string | null;
-  timer_mode: 'per_question' | 'global' | null;
-  timer_seconds: number | null;
-  question_goal: number | null;
-  started_at: string | null;
-  is_founder: boolean | null;
-  member_count: number | null;
-};
-
-async function getCurrentAuthUser() {
-  const supabase = createSupabaseServerClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  return { supabase, user };
 }
 
 async function requireSessionMember(sessionId: string, locale: AppLocale) {
@@ -68,55 +45,21 @@ async function requireSessionMember(sessionId: string, locale: AppLocale) {
     redirect(`/${locale}/auth/login`);
   }
 
-  const { data: access } = await (supabase as unknown as {
-    schema: (schemaName: string) => {
-      from: (relation: string) => {
-        select: (columns: string) => {
-          eq: (column: string, value: string) => {
-            eq: (column: string, value: string) => {
-              maybeSingle: () => Promise<{ data: SessionRuntimeAccessRow | null }>;
-            };
-          };
-        };
-      };
-    };
-  })
-    .schema('public')
-    .from('session_runtime_access')
-    .select(
-      'session_id, group_id, status, leader_id, timer_mode, timer_seconds, question_goal, started_at, is_founder, member_count',
-    )
-    .eq('session_id', sessionId)
-    .eq('user_id', user.id)
-    .maybeSingle();
+  const access = await loadSessionRuntimeAccess(supabase, sessionId, user.id);
+  const session = getSessionAccessSnapshot(access);
 
-  if (
-    !access?.session_id ||
-    !access.group_id ||
-    !access.status ||
-    !access.timer_mode ||
-    typeof access.timer_seconds !== 'number' ||
-    typeof access.question_goal !== 'number'
-  ) {
+  if (!session) {
     redirect(withFeedback(`/${locale}/dashboard?view=sessions`, 'error', t('notAuthorized')));
   }
+  const safeAccess = access!;
 
   return {
     supabase,
     user,
-    session: {
-      id: access.session_id,
-      group_id: access.group_id,
-      status: access.status,
-      leader_id: access.leader_id,
-      timer_mode: access.timer_mode,
-      timer_seconds: access.timer_seconds,
-      question_goal: access.question_goal,
-      started_at: access.started_at,
-    },
+    session,
     membership: {
-      is_founder: Boolean(access.is_founder),
-      member_count: access.member_count ?? 0,
+      is_founder: Boolean(safeAccess.is_founder),
+      member_count: safeAccess.member_count ?? 0,
     },
     t,
   };
@@ -136,119 +79,25 @@ async function requireSessionMemberWithPerf(
     redirect(`/${locale}/auth/login`);
   }
 
-  const { data: access } = await (supabase as unknown as {
-    schema: (schemaName: string) => {
-      from: (relation: string) => {
-        select: (columns: string) => {
-          eq: (column: string, value: string) => {
-            eq: (column: string, value: string) => {
-              maybeSingle: () => Promise<{ data: SessionRuntimeAccessRow | null }>;
-            };
-          };
-        };
-      };
-    };
-  })
-    .schema('public')
-    .from('session_runtime_access')
-    .select(
-      'session_id, group_id, status, leader_id, timer_mode, timer_seconds, question_goal, started_at, is_founder, member_count',
-    )
-    .eq('session_id', sessionId)
-    .eq('user_id', user.id)
-    .maybeSingle();
+  const access = await loadSessionRuntimeAccess(supabase, sessionId, user.id);
   perf.step('session_loaded');
+  const session = getSessionAccessSnapshot(access);
 
-  if (
-    !access?.session_id ||
-    !access.group_id ||
-    !access.status ||
-    !access.timer_mode ||
-    typeof access.timer_seconds !== 'number' ||
-    typeof access.question_goal !== 'number'
-  ) {
+  if (!session) {
     redirect(withFeedback(`/${locale}/dashboard?view=sessions`, 'error', t('notAuthorized')));
   }
   perf.step('membership_loaded');
+  const safeAccess = access!;
 
   return {
     supabase,
     user,
-    session: {
-      id: access.session_id,
-      group_id: access.group_id,
-      status: access.status,
-      leader_id: access.leader_id,
-      timer_mode: access.timer_mode,
-      timer_seconds: access.timer_seconds,
-      question_goal: access.question_goal,
-      started_at: access.started_at,
-    },
+    session,
     membership: {
-      is_founder: Boolean(access.is_founder),
-      member_count: access.member_count ?? 0,
+      is_founder: Boolean(safeAccess.is_founder),
+      member_count: safeAccess.member_count ?? 0,
     },
     t,
-  };
-}
-
-async function ensureQuestion(
-  supabase: ReturnType<typeof createSupabaseServerClient>,
-  sessionId: string,
-  orderIndex: number,
-  userId: string,
-  session: { timer_mode: 'per_question' | 'global'; timer_seconds: number; started_at: string | null },
-) {
-  const now = new Date();
-  const answerDeadlineAt =
-    session.timer_mode === 'global'
-      ? getGlobalDeadline(session.started_at ?? now.toISOString(), session.timer_seconds)
-      : new Date(now.getTime() + session.timer_seconds * 1000);
-
-  const { data: existing } = await supabase
-    .schema('public')
-    .from('questions')
-    .select('id, answer_deadline_at')
-    .eq('session_id', sessionId)
-    .eq('order_index', orderIndex)
-    .maybeSingle();
-
-  if (existing) {
-    if (!existing.answer_deadline_at) {
-      await supabase
-        .schema('public')
-        .from('questions')
-        .update({ answer_deadline_at: answerDeadlineAt.toISOString(), phase: 'answering' })
-        .eq('id', existing.id);
-    }
-    return {
-      id: existing.id,
-      answerDeadlineAt: existing.answer_deadline_at ?? answerDeadlineAt.toISOString(),
-    };
-  }
-
-  const { data: created, error } = await supabase
-    .schema('public')
-    .from('questions')
-    .insert({
-      session_id: sessionId,
-      asked_by: userId,
-      options: ANSWER_OPTIONS,
-      order_index: orderIndex,
-      phase: 'answering',
-      launched_at: now.toISOString(),
-      answer_deadline_at: answerDeadlineAt.toISOString(),
-    })
-    .select('id, answer_deadline_at')
-    .single();
-
-  if (error || !created) {
-    throw new Error('question_create_failed');
-  }
-
-  return {
-    id: created.id,
-    answerDeadlineAt: created.answer_deadline_at ?? answerDeadlineAt.toISOString(),
   };
 }
 
@@ -289,6 +138,7 @@ export async function initializeSessionFlowAction(formData: FormData) {
 export async function submitSessionStepAction(formData: FormData) {
   const locale = formData.get('locale') as AppLocale;
   const sessionId = formData.get('sessionId') as string;
+  const currentQuestionId = (formData.get('questionId') as string | null)?.trim() || null;
   const questionIndex = Number(formData.get('questionIndex'));
   const selectedOption = (formData.get('selectedOption') as string | null)?.toUpperCase() ?? '';
   const customOption = (formData.get('customOption') as string | null)?.trim().toUpperCase() ?? '';
@@ -305,26 +155,34 @@ export async function submitSessionStepAction(formData: FormData) {
     questionIndex < 0 ||
     questionIndex >= session.question_goal ||
     (!ANSWER_OPTIONS.includes(selectedOption as (typeof ANSWER_OPTIONS)[number]) && selectedOption !== '?') ||
-    (selectedOption === '?' && !isCustomAnswerLetter(customOption)) ||
+    (selectedOption === '?' &&
+      (!isCustomAnswerLetter(customOption) ||
+        ANSWER_OPTIONS.includes(customOption as (typeof ANSWER_OPTIONS)[number]))) ||
     !confidence
   ) {
     redirect(withFeedback(`/${locale}/sessions/${sessionId}`, 'error', t('missingFields')));
   }
 
-  let ensuredQuestion: { id: string; answerDeadlineAt: string };
+  let ensuredQuestion: { id: string; answerDeadlineAt: string | null };
   try {
-    ensuredQuestion = await ensureQuestion(supabase, sessionId, questionIndex, user.id, session);
+    ensuredQuestion = await resolveSessionQuestion(supabase, {
+      sessionId,
+      questionId: currentQuestionId,
+      questionIndex,
+      userId: user.id,
+      session,
+    });
   } catch {
     redirect(withFeedback(`/${locale}/sessions/${sessionId}`, 'error', t('actionFailed')));
   }
   perf.step('question_ensured');
 
-  const questionId = ensuredQuestion.id;
+  const resolvedQuestionId = ensuredQuestion.id;
   const answerDeadlineAt = ensuredQuestion.answerDeadlineAt;
   if (answerDeadlineAt && new Date(answerDeadlineAt).getTime() <= Date.now()) {
     await supabase.schema('public').from('answers').upsert(
       {
-        question_id: questionId,
+        question_id: resolvedQuestionId,
         user_id: user.id,
         selected_option: '?',
         confidence: null,
@@ -332,14 +190,14 @@ export async function submitSessionStepAction(formData: FormData) {
       { onConflict: 'question_id,user_id' },
     );
     perf.step('timeout_answer_upserted');
-    perf.done({ mode: 'expired', questionId });
+    perf.done({ mode: 'expired', questionId: resolvedQuestionId });
 
     redirect(`/${locale}/sessions/${sessionId}?q=${questionIndex}`);
   }
 
   await supabase.schema('public').from('answers').upsert(
     {
-      question_id: questionId,
+      question_id: resolvedQuestionId,
       user_id: user.id,
       selected_option: resolvedSelectedOption,
       confidence,
@@ -356,7 +214,7 @@ export async function submitSessionStepAction(formData: FormData) {
       groupId: session.group_id,
       sessionId,
       metadata: {
-        question_id: questionId,
+        question_id: resolvedQuestionId,
         question_index: questionIndex,
         selected_option: resolvedSelectedOption,
         confidence,
@@ -368,7 +226,7 @@ export async function submitSessionStepAction(formData: FormData) {
   perf.step('deferred_side_effects_started');
   perf.done({
     mode: 'submitted',
-    questionId,
+    questionId: resolvedQuestionId,
     selectedOption: resolvedSelectedOption,
     confidence,
   });
@@ -379,6 +237,7 @@ export async function submitSessionStepAction(formData: FormData) {
 export async function timeoutSessionStepAction(formData: FormData) {
   const locale = formData.get('locale') as AppLocale;
   const sessionId = formData.get('sessionId') as string;
+  const currentQuestionId = (formData.get('questionId') as string | null)?.trim() || null;
   const questionIndex = Number(formData.get('questionIndex'));
   const { supabase, user, session, t } = await requireSessionMember(sessionId, locale);
 
@@ -388,15 +247,21 @@ export async function timeoutSessionStepAction(formData: FormData) {
 
   let ensuredQuestion: { id: string };
   try {
-    ensuredQuestion = await ensureQuestion(supabase, sessionId, questionIndex, user.id, session);
+    ensuredQuestion = await resolveSessionQuestion(supabase, {
+      sessionId,
+      questionId: currentQuestionId,
+      questionIndex,
+      userId: user.id,
+      session,
+    });
   } catch {
     redirect(withFeedback(`/${locale}/sessions/${sessionId}`, 'error', t('actionFailed')));
   }
 
-  const questionId = ensuredQuestion.id;
+  const resolvedQuestionId = ensuredQuestion.id;
   await supabase.schema('public').from('answers').upsert(
     {
-      question_id: questionId,
+      question_id: resolvedQuestionId,
       user_id: user.id,
       selected_option: '?',
       confidence: null,

--- a/app/[locale]/sessions/[sessionId]/page.tsx
+++ b/app/[locale]/sessions/[sessionId]/page.tsx
@@ -3,9 +3,9 @@ import { notFound } from 'next/navigation';
 import { getTranslations } from 'next-intl/server';
 
 import { FeedbackBanner } from '@/components/app/feedback-banner';
-import { RealtimeRefresh } from '@/components/app/realtime-refresh';
 import { SessionActiveRuntime } from '@/components/session/session-active-runtime';
 import { ReviewAnswerForm } from '@/components/session/session-flow-client';
+import { SessionStageRefresh } from '@/components/session/session-stage-refresh';
 import { SubmitButton } from '@/components/ui/submit-button';
 import { Link } from '@/i18n/navigation';
 import type { AppLocale } from '@/i18n/routing';
@@ -83,12 +83,6 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
   const currentIndex = Math.max(0, Math.min(data.resolvedQuestionIndex ?? requestedQuestionIndex ?? 0, questionGoal - 1));
   const questions = [...data.questions].sort((left, right) => left.order_index - right.order_index);
   const question = questions.find((item) => item.order_index === currentIndex) ?? questions[currentIndex] ?? questions[0] ?? null;
-  const realtimeTables = [
-    { table: 'sessions', filter: `id=eq.${params.sessionId}` },
-    { table: 'questions', filter: `session_id=eq.${params.sessionId}` },
-    ...(question ? [{ table: 'answers', filter: `question_id=eq.${question.id}` }] : []),
-    { table: 'question_classifications', filter: `session_id=eq.${params.sessionId}` },
-  ];
   const answeredCount = data.answeredCount;
   const memberCount = Math.max(data.members.length, 1);
   const shouldShowCompletion =
@@ -106,7 +100,7 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
 
     return (
       <main className="flex flex-1 items-center justify-center px-4">
-        <RealtimeRefresh channelName={`session:${params.sessionId}`} tables={realtimeTables} />
+        <SessionStageRefresh sessionId={params.sessionId} expectedStatus="scheduled" />
         <FeedbackBanner message={searchParams.feedbackMessage} tone={searchParams.feedbackTone} />
         <section className="flex w-full max-w-md flex-col items-center text-center">
           <div className="flex h-16 w-16 items-center justify-center rounded-full bg-brand/10 text-brand">
@@ -275,7 +269,7 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
   if (!question) {
     return (
       <main className="flex flex-1 flex-col">
-        <RealtimeRefresh channelName={`session:${params.sessionId}`} tables={realtimeTables} />
+        <SessionStageRefresh sessionId={params.sessionId} expectedStatus={data.session.status} expectedQuestionId={null} />
         <FeedbackBanner message={searchParams.feedbackMessage} tone={searchParams.feedbackTone} />
         <section className="flex flex-1 items-center justify-center px-4 text-center text-sm font-bold text-slate-500">
           {t('loadingSession')}

--- a/app/[locale]/sessions/[sessionId]/page.tsx
+++ b/app/[locale]/sessions/[sessionId]/page.tsx
@@ -4,7 +4,8 @@ import { getTranslations } from 'next-intl/server';
 
 import { FeedbackBanner } from '@/components/app/feedback-banner';
 import { RealtimeRefresh } from '@/components/app/realtime-refresh';
-import { ReviewAnswerForm, SessionAnswerForm, SessionHeaderMeta } from '@/components/session/session-flow-client';
+import { SessionActiveRuntime } from '@/components/session/session-active-runtime';
+import { ReviewAnswerForm } from '@/components/session/session-flow-client';
 import { SubmitButton } from '@/components/ui/submit-button';
 import { Link } from '@/i18n/navigation';
 import type { AppLocale } from '@/i18n/routing';
@@ -291,54 +292,37 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
 
   return (
     <main className="flex flex-1 flex-col">
-      <RealtimeRefresh channelName={`session:${params.sessionId}`} tables={realtimeTables} />
       <FeedbackBanner message={searchParams.feedbackMessage} tone={searchParams.feedbackTone} />
-      <header className="border-b border-white/[0.07]">
-        <div className="mx-auto flex min-h-16 w-full max-w-[560px] items-center justify-between gap-3 px-4 py-3 sm:h-16 sm:py-0">
-          <Link href="/dashboard?view=sessions" prefetch={false} className="text-slate-500 hover:text-white">
-            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-          </Link>
-          <div className="text-center">
-            <p className="text-xs font-bold uppercase tracking-[0.18em] text-slate-500">{t('questionUpper')}</p>
-            <p className="text-xl font-extrabold text-white">
-              {currentIndex + 1}
-              <span className="text-sm text-slate-500">/{questionGoal}</span>
-            </p>
-          </div>
-          <SessionHeaderMeta submittedCount={submittedCount} memberCount={memberCount} answerDeadlineAt={question.answer_deadline_at} />
-        </div>
-      </header>
-
-      <section className="mx-auto w-full max-w-[560px] px-4 py-7">
-        <SessionAnswerForm
-          key={question.id}
-          action={submitSessionStepAction}
-          timeoutAction={timeoutSessionStepAction}
-          advanceAction={advanceSessionStepAction}
-          locale={locale}
-          sessionId={params.sessionId}
-          questionId={question.id}
-          questionIndex={currentIndex}
-          initialAnswer={myAnswer?.selected_option}
-          initialConfidence={myAnswer?.confidence as ConfidenceLevel | null | undefined}
-          answerDeadlineAt={question.answer_deadline_at}
-          submittedCount={submittedCount}
-          memberCount={memberCount}
-          labels={{
-            confidenceTitle: t('confidenceLevel'),
-            confidenceLow: t('confidenceLow'),
-            confidenceMedium: t('confidenceMedium'),
-            confidenceHigh: t('confidenceHigh'),
-            customOptionLabel: t('customOptionLabel'),
-            customOptionPlaceholder: t('customOptionPlaceholder'),
-            submit: t('submitAnswer'),
-            submitPending: t('submitAnswerPending'),
-            nextQuestion: t('nextQuestion'),
-            nextQuestionPending: t('nextQuestionPending'),
-            allAnswersReceived: t('allAnswersSubmitted'),
-          }}
-        />
-      </section>
+      <SessionActiveRuntime
+        key={question.id}
+        action={submitSessionStepAction}
+        timeoutAction={timeoutSessionStepAction}
+        advanceAction={advanceSessionStepAction}
+        locale={locale}
+        sessionId={params.sessionId}
+        questionId={question.id}
+        questionIndex={currentIndex}
+        questionGoal={questionGoal}
+        initialAnswer={myAnswer?.selected_option}
+        initialConfidence={myAnswer?.confidence as ConfidenceLevel | null | undefined}
+        initialSubmittedCount={submittedCount}
+        initialMemberCount={memberCount}
+        initialAnswerDeadlineAt={question.answer_deadline_at}
+        labels={{
+          questionUpper: t('questionUpper'),
+          confidenceTitle: t('confidenceLevel'),
+          confidenceLow: t('confidenceLow'),
+          confidenceMedium: t('confidenceMedium'),
+          confidenceHigh: t('confidenceHigh'),
+          customOptionLabel: t('customOptionLabel'),
+          customOptionPlaceholder: t('customOptionPlaceholder'),
+          submit: t('submitAnswer'),
+          submitPending: t('submitAnswerPending'),
+          nextQuestion: t('nextQuestion'),
+          nextQuestionPending: t('nextQuestionPending'),
+          allAnswersReceived: t('allAnswersSubmitted'),
+        }}
+      />
     </main>
   );
 }

--- a/app/[locale]/sessions/[sessionId]/page.tsx
+++ b/app/[locale]/sessions/[sessionId]/page.tsx
@@ -20,8 +20,6 @@ import {
   initializeSessionFlowAction,
   quitIncompleteSessionAction,
   saveReviewAnswerAction,
-  submitSessionStepAction,
-  timeoutSessionStepAction,
 } from './actions';
 
 type SessionPageProps = {
@@ -289,8 +287,6 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
       <FeedbackBanner message={searchParams.feedbackMessage} tone={searchParams.feedbackTone} />
       <SessionActiveRuntime
         key={question.id}
-        action={submitSessionStepAction}
-        timeoutAction={timeoutSessionStepAction}
         advanceAction={advanceSessionStepAction}
         locale={locale}
         sessionId={params.sessionId}

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+export async function POST() {
+  const supabase = createSupabaseServerClient();
+  const { error } = await supabase.auth.signOut();
+
+  if (error) {
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/groups/weekly-progress/route.ts
+++ b/app/api/groups/weekly-progress/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+
+import { getGroupWeeklyProgress } from '@/lib/groups/server';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+export async function GET(request: Request) {
+  const groupId = new URL(request.url).searchParams.get('groupId');
+  if (!groupId) {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
+
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ ok: false }, { status: 401 });
+  }
+
+  const { data: membership } = await supabase
+    .schema('public')
+    .from('group_members')
+    .select('group_id')
+    .eq('group_id', groupId)
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (!membership) {
+    return NextResponse.json({ ok: false }, { status: 403 });
+  }
+
+  const progress = await getGroupWeeklyProgress(groupId);
+  return NextResponse.json({ ok: true, ...progress });
+}

--- a/app/api/sessions/[sessionId]/answer/route.ts
+++ b/app/api/sessions/[sessionId]/answer/route.ts
@@ -1,0 +1,208 @@
+import { NextResponse } from 'next/server';
+import { getTranslations } from 'next-intl/server';
+
+import type { AppLocale } from '@/i18n/routing';
+import { isConfidenceLevel } from '@/lib/demo/confidence';
+import { APP_EVENTS } from '@/lib/logging/events';
+import { logAppEvent } from '@/lib/logging/logger';
+import { refreshDashboardProfileAnalytics } from '@/lib/demo/profile-analytics';
+import { sendTrialWarningEmailIfNeeded } from '@/lib/notifications/trial-progress';
+import { createPerfTracker } from '@/lib/observability/perf';
+import {
+  getCurrentAuthUser,
+  getSessionAccessSnapshot,
+  isCustomAnswerLetter,
+  loadSessionRuntimeAccess,
+  resolveSessionQuestion,
+} from '@/lib/session/flow';
+import { ANSWER_OPTIONS } from '@/lib/types/demo';
+
+type RouteContext = {
+  params: { sessionId: string };
+};
+
+type SubmitPayload = {
+  locale?: string;
+  questionId?: string | null;
+  questionIndex?: number;
+  selectedOption?: string | null;
+  customOption?: string | null;
+  confidence?: string | null;
+  mode?: 'submit' | 'timeout';
+};
+
+function runDeferredTasks(tasks: Array<Promise<unknown>>) {
+  void Promise.allSettled(tasks);
+}
+
+export async function POST(request: Request, { params }: RouteContext) {
+  const sessionId = params.sessionId;
+  const body = (await request.json().catch(() => null)) as SubmitPayload | null;
+  const locale = (body?.locale ?? 'en') as AppLocale;
+  const questionId = body?.questionId?.trim() || null;
+  const questionIndex = Number(body?.questionIndex);
+  const selectedOption = body?.selectedOption?.toUpperCase() ?? '';
+  const customOption = body?.customOption?.trim().toUpperCase() ?? '';
+  const confidenceValue = body?.confidence;
+  const confidence =
+    typeof confidenceValue === 'string' && isConfidenceLevel(confidenceValue) ? confidenceValue : null;
+  const mode = body?.mode === 'timeout' ? 'timeout' : 'submit';
+  const perf = createPerfTracker(`submitSessionAnswerRoute:${sessionId}:${questionIndex}`);
+  const t = await getTranslations({ locale, namespace: 'Feedback' });
+
+  if (!sessionId) {
+    return NextResponse.json({ ok: false, message: t('actionFailed') }, { status: 400 });
+  }
+
+  const { supabase, user } = await getCurrentAuthUser();
+  perf.step('auth_loaded');
+
+  if (!user) {
+    return NextResponse.json(
+      { ok: false, redirectTo: `/${locale}/auth/login`, message: t('notAuthorized') },
+      { status: 401 },
+    );
+  }
+
+  const access = await loadSessionRuntimeAccess(supabase, sessionId, user.id);
+  perf.step('session_loaded');
+  const session = getSessionAccessSnapshot(access);
+
+  if (!session) {
+    return NextResponse.json(
+      { ok: false, redirectTo: `/${locale}/dashboard?view=sessions`, message: t('notAuthorized') },
+      { status: 403 },
+    );
+  }
+  perf.setContext({
+    locale,
+    userId: user.id,
+    groupId: session.group_id,
+    sessionId,
+    minDurationMs: 250,
+    metadata: {
+      trace_group: 'sessions',
+      trace_kind: 'answer_submit',
+      question_id: questionId,
+      question_index: questionIndex,
+      submit_mode: mode,
+    },
+  });
+  perf.step('membership_loaded');
+
+  if (
+    session.status !== 'active' ||
+    !Number.isInteger(questionIndex) ||
+    questionIndex < 0 ||
+    questionIndex >= session.question_goal
+  ) {
+    return NextResponse.json({ ok: false, message: t('actionFailed') }, { status: 400 });
+  }
+
+  if (
+    mode === 'submit' &&
+    ((!ANSWER_OPTIONS.includes(selectedOption as (typeof ANSWER_OPTIONS)[number]) && selectedOption !== '?') ||
+      (selectedOption === '?' &&
+        (!isCustomAnswerLetter(customOption) ||
+          ANSWER_OPTIONS.includes(customOption as (typeof ANSWER_OPTIONS)[number]))) ||
+      !confidence)
+  ) {
+    return NextResponse.json({ ok: false, message: t('missingFields') }, { status: 400 });
+  }
+
+  let ensuredQuestion: { id: string; answerDeadlineAt: string | null };
+  try {
+    ensuredQuestion = await resolveSessionQuestion(supabase, {
+      sessionId,
+      questionId,
+      questionIndex,
+      userId: user.id,
+      session,
+    });
+  } catch {
+    return NextResponse.json({ ok: false, message: t('actionFailed') }, { status: 500 });
+  }
+  perf.step('question_ensured');
+
+  const questionAnswerDeadlineAt = ensuredQuestion.answerDeadlineAt;
+  const isExpired = questionAnswerDeadlineAt ? new Date(questionAnswerDeadlineAt).getTime() <= Date.now() : false;
+
+  if (mode === 'timeout' || isExpired) {
+    await supabase.schema('public').from('answers').upsert(
+      {
+        question_id: ensuredQuestion.id,
+        user_id: user.id,
+        selected_option: '?',
+        confidence: null,
+      },
+      { onConflict: 'question_id,user_id' },
+    );
+    perf.step('answer_upserted');
+    try {
+      await refreshDashboardProfileAnalytics();
+      perf.step('analytics_refreshed');
+    } catch {
+      // Preserve the saved answer even if analytics refresh is temporarily unavailable.
+    }
+    perf.done({ mode: 'timeout', questionId: ensuredQuestion.id });
+
+    return NextResponse.json({
+      ok: true,
+      mode: 'timeout',
+      questionId: ensuredQuestion.id,
+      selectedOption: '?',
+      confidence: null,
+    });
+  }
+
+  const resolvedSelectedOption = selectedOption === '?' ? customOption : selectedOption;
+  await supabase.schema('public').from('answers').upsert(
+    {
+      question_id: ensuredQuestion.id,
+      user_id: user.id,
+      selected_option: resolvedSelectedOption,
+      confidence,
+    },
+    { onConflict: 'question_id,user_id' },
+  );
+  perf.step('answer_upserted');
+  try {
+    await refreshDashboardProfileAnalytics();
+    perf.step('analytics_refreshed');
+  } catch {
+    // Preserve the saved answer even if analytics refresh is temporarily unavailable.
+  }
+
+  runDeferredTasks([
+    logAppEvent({
+      eventName: APP_EVENTS.answerSubmitted,
+      locale,
+      userId: user.id,
+      groupId: session.group_id,
+      sessionId,
+      metadata: {
+        question_id: ensuredQuestion.id,
+        question_index: questionIndex,
+        selected_option: resolvedSelectedOption,
+        confidence,
+        source: 'self_paced_session_flow',
+      },
+    }),
+    sendTrialWarningEmailIfNeeded(user.id),
+  ]);
+  perf.step('deferred_side_effects_started');
+  perf.done({
+    mode: 'submitted',
+    questionId: ensuredQuestion.id,
+    selectedOption: resolvedSelectedOption,
+    confidence,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    mode: 'submitted',
+    questionId: ensuredQuestion.id,
+    selectedOption: resolvedSelectedOption,
+    confidence,
+  });
+}

--- a/app/api/sessions/[sessionId]/runtime/route.ts
+++ b/app/api/sessions/[sessionId]/runtime/route.ts
@@ -1,16 +1,10 @@
 import { NextResponse } from 'next/server';
 
 import { createPerfTracker } from '@/lib/observability/perf';
-import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { getCurrentAuthUser, loadSessionRuntimeAccess } from '@/lib/session/flow';
 
 type RouteContext = {
   params: { sessionId: string };
-};
-
-type SessionRuntimeAccessRow = {
-  session_id: string | null;
-  status: string | null;
-  member_count: number | null;
 };
 
 export async function GET(request: Request, { params }: RouteContext) {
@@ -22,35 +16,25 @@ export async function GET(request: Request, { params }: RouteContext) {
     return NextResponse.json({ ok: false }, { status: 400 });
   }
 
-  const supabase = createSupabaseServerClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { supabase, user } = await getCurrentAuthUser();
   perf.step('auth_loaded');
 
   if (!user) {
     return NextResponse.json({ ok: false }, { status: 401 });
   }
+  perf.setContext({
+    userId: user.id,
+    sessionId,
+    sampleRate: 0.2,
+    minDurationMs: 1200,
+    metadata: {
+      trace_group: 'sessions',
+      trace_kind: 'runtime',
+      question_id: questionId,
+    },
+  });
 
-  const { data: access } = await (supabase as unknown as {
-    schema: (schemaName: string) => {
-      from: (relation: string) => {
-        select: (columns: string) => {
-          eq: (column: string, value: string) => {
-            eq: (column: string, value: string) => {
-              maybeSingle: () => Promise<{ data: SessionRuntimeAccessRow | null }>;
-            };
-          };
-        };
-      };
-    };
-  })
-    .schema('public')
-    .from('session_runtime_access')
-    .select('session_id, status, member_count')
-    .eq('session_id', sessionId)
-    .eq('user_id', user.id)
-    .maybeSingle();
+  const access = await loadSessionRuntimeAccess(supabase, sessionId, user.id);
   perf.step('session_loaded');
 
   if (!access?.session_id || !access.status) {

--- a/app/api/sessions/[sessionId]/runtime/route.ts
+++ b/app/api/sessions/[sessionId]/runtime/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server';
+
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+type RouteContext = {
+  params: { sessionId: string };
+};
+
+export async function GET(request: Request, { params }: RouteContext) {
+  const questionId = new URL(request.url).searchParams.get('questionId');
+  const sessionId = params.sessionId;
+
+  if (!sessionId || !questionId) {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
+
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ ok: false }, { status: 401 });
+  }
+
+  const { data: session } = await supabase
+    .schema('public')
+    .from('sessions')
+    .select('id, group_id, status')
+    .eq('id', sessionId)
+    .maybeSingle();
+
+  if (!session) {
+    return NextResponse.json({ ok: false }, { status: 404 });
+  }
+
+  const { data: membership } = await supabase
+    .schema('public')
+    .from('group_members')
+    .select('user_id')
+    .eq('group_id', session.group_id)
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (!membership) {
+    return NextResponse.json({ ok: false }, { status: 403 });
+  }
+
+  const [{ data: question }, { count: submittedCount }, { count: memberCount }] = await Promise.all([
+    supabase
+      .schema('public')
+      .from('questions')
+      .select('id, phase, answer_deadline_at')
+      .eq('id', questionId)
+      .eq('session_id', sessionId)
+      .maybeSingle(),
+    supabase
+      .schema('public')
+      .from('answers')
+      .select('*', { count: 'exact', head: true })
+      .eq('question_id', questionId),
+    supabase
+      .schema('public')
+      .from('group_members')
+      .select('*', { count: 'exact', head: true })
+      .eq('group_id', session.group_id),
+  ]);
+
+  return NextResponse.json({
+    ok: true,
+    sessionStatus: session.status,
+    questionId: question?.id ?? null,
+    questionPhase: question?.phase ?? null,
+    answerDeadlineAt: question?.answer_deadline_at ?? null,
+    submittedCount: submittedCount ?? 0,
+    memberCount: memberCount ?? 0,
+  });
+}

--- a/app/api/sessions/[sessionId]/runtime/route.ts
+++ b/app/api/sessions/[sessionId]/runtime/route.ts
@@ -7,6 +7,12 @@ type RouteContext = {
   params: { sessionId: string };
 };
 
+type SessionRuntimeAccessRow = {
+  session_id: string | null;
+  status: string | null;
+  member_count: number | null;
+};
+
 export async function GET(request: Request, { params }: RouteContext) {
   const questionId = new URL(request.url).searchParams.get('questionId');
   const sessionId = params.sessionId;
@@ -18,50 +24,42 @@ export async function GET(request: Request, { params }: RouteContext) {
 
   const supabase = createSupabaseServerClient();
   const {
-    data: { session: authSession },
-  } = await supabase.auth.getSession();
-  const expiresSoon = authSession?.expires_at ? authSession.expires_at * 1000 <= Date.now() + 30_000 : false;
-  let user = authSession?.user ?? null;
-
-  if (!user || expiresSoon) {
-    const {
-      data: { user: refreshedUser },
-    } = await supabase.auth.getUser();
-    user = refreshedUser;
-  }
+    data: { user },
+  } = await supabase.auth.getUser();
   perf.step('auth_loaded');
 
   if (!user) {
     return NextResponse.json({ ok: false }, { status: 401 });
   }
 
-  const { data: session } = await supabase
+  const { data: access } = await (supabase as unknown as {
+    schema: (schemaName: string) => {
+      from: (relation: string) => {
+        select: (columns: string) => {
+          eq: (column: string, value: string) => {
+            eq: (column: string, value: string) => {
+              maybeSingle: () => Promise<{ data: SessionRuntimeAccessRow | null }>;
+            };
+          };
+        };
+      };
+    };
+  })
     .schema('public')
-    .from('sessions')
-    .select('id, group_id, status')
-    .eq('id', sessionId)
+    .from('session_runtime_access')
+    .select('session_id, status, member_count')
+    .eq('session_id', sessionId)
+    .eq('user_id', user.id)
     .maybeSingle();
   perf.step('session_loaded');
 
-  if (!session) {
+  if (!access?.session_id || !access.status) {
     return NextResponse.json({ ok: false }, { status: 404 });
   }
-
-  const { data: membership } = await supabase
-    .schema('public')
-    .from('group_members')
-    .select('user_id')
-    .eq('group_id', session.group_id)
-    .eq('user_id', user.id)
-    .maybeSingle();
   perf.step('membership_loaded');
 
-  if (!membership) {
-    return NextResponse.json({ ok: false }, { status: 403 });
-  }
-
   if (questionId) {
-    const [{ data: question }, { count: memberCount }, { count: submittedCount }] = await Promise.all([
+    const [{ data: question }, { count: submittedCount }] = await Promise.all([
       supabase
         .schema('public')
         .from('questions')
@@ -69,11 +67,6 @@ export async function GET(request: Request, { params }: RouteContext) {
         .eq('id', questionId)
         .eq('session_id', sessionId)
         .maybeSingle(),
-      supabase
-        .schema('public')
-        .from('group_members')
-        .select('*', { count: 'exact', head: true })
-        .eq('group_id', session.group_id),
       supabase
         .schema('public')
         .from('answers')
@@ -85,50 +78,43 @@ export async function GET(request: Request, { params }: RouteContext) {
       mode: 'question',
       questionFound: Boolean(question?.id),
       submittedCount: submittedCount ?? 0,
-      memberCount: memberCount ?? 0,
+      memberCount: access.member_count ?? 0,
     });
 
     return NextResponse.json({
       ok: true,
-      sessionStatus: session.status,
+      sessionStatus: access.status,
       questionId: question?.id ?? null,
       questionPhase: question?.phase ?? null,
       answerDeadlineAt: question?.answer_deadline_at ?? null,
       submittedCount: submittedCount ?? 0,
-      memberCount: memberCount ?? 0,
+      memberCount: access.member_count ?? 0,
     });
   }
 
-  const [{ data: question }, { count: memberCount }] = await Promise.all([
-    supabase
-      .schema('public')
-      .from('questions')
-      .select('id, phase, answer_deadline_at')
-      .eq('session_id', sessionId)
-      .not('launched_at', 'is', null)
-      .order('order_index', { ascending: false })
-      .limit(1)
-      .maybeSingle(),
-    supabase
-      .schema('public')
-      .from('group_members')
-      .select('*', { count: 'exact', head: true })
-      .eq('group_id', session.group_id),
-  ]);
+  const { data: question } = await supabase
+    .schema('public')
+    .from('questions')
+    .select('id, phase, answer_deadline_at')
+    .eq('session_id', sessionId)
+    .not('launched_at', 'is', null)
+    .order('order_index', { ascending: false })
+    .limit(1)
+    .maybeSingle();
   perf.step('latest_question_loaded');
   perf.done({
     mode: 'latest',
     questionFound: Boolean(question?.id),
-    memberCount: memberCount ?? 0,
+    memberCount: access.member_count ?? 0,
   });
 
   return NextResponse.json({
     ok: true,
-    sessionStatus: session.status,
+    sessionStatus: access.status,
     questionId: question?.id ?? null,
     questionPhase: question?.phase ?? null,
     answerDeadlineAt: question?.answer_deadline_at ?? null,
     submittedCount: 0,
-    memberCount: memberCount ?? 0,
+    memberCount: access.member_count ?? 0,
   });
 }

--- a/app/api/sessions/[sessionId]/runtime/route.ts
+++ b/app/api/sessions/[sessionId]/runtime/route.ts
@@ -18,8 +18,17 @@ export async function GET(request: Request, { params }: RouteContext) {
 
   const supabase = createSupabaseServerClient();
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session: authSession },
+  } = await supabase.auth.getSession();
+  const expiresSoon = authSession?.expires_at ? authSession.expires_at * 1000 <= Date.now() + 30_000 : false;
+  let user = authSession?.user ?? null;
+
+  if (!user || expiresSoon) {
+    const {
+      data: { user: refreshedUser },
+    } = await supabase.auth.getUser();
+    user = refreshedUser;
+  }
   perf.step('auth_loaded');
 
   if (!user) {

--- a/app/api/sessions/[sessionId]/runtime/route.ts
+++ b/app/api/sessions/[sessionId]/runtime/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { createPerfTracker } from '@/lib/observability/perf';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 type RouteContext = {
@@ -9,6 +10,7 @@ type RouteContext = {
 export async function GET(request: Request, { params }: RouteContext) {
   const questionId = new URL(request.url).searchParams.get('questionId');
   const sessionId = params.sessionId;
+  const perf = createPerfTracker(`sessionRuntime:${sessionId}:${questionId ?? 'latest'}`);
 
   if (!sessionId) {
     return NextResponse.json({ ok: false }, { status: 400 });
@@ -18,6 +20,7 @@ export async function GET(request: Request, { params }: RouteContext) {
   const {
     data: { user },
   } = await supabase.auth.getUser();
+  perf.step('auth_loaded');
 
   if (!user) {
     return NextResponse.json({ ok: false }, { status: 401 });
@@ -29,6 +32,7 @@ export async function GET(request: Request, { params }: RouteContext) {
     .select('id, group_id, status')
     .eq('id', sessionId)
     .maybeSingle();
+  perf.step('session_loaded');
 
   if (!session) {
     return NextResponse.json({ ok: false }, { status: 404 });
@@ -41,6 +45,7 @@ export async function GET(request: Request, { params }: RouteContext) {
     .eq('group_id', session.group_id)
     .eq('user_id', user.id)
     .maybeSingle();
+  perf.step('membership_loaded');
 
   if (!membership) {
     return NextResponse.json({ ok: false }, { status: 403 });
@@ -66,6 +71,13 @@ export async function GET(request: Request, { params }: RouteContext) {
         .select('*', { count: 'exact', head: true })
         .eq('question_id', questionId),
     ]);
+    perf.step('question_and_counts_loaded');
+    perf.done({
+      mode: 'question',
+      questionFound: Boolean(question?.id),
+      submittedCount: submittedCount ?? 0,
+      memberCount: memberCount ?? 0,
+    });
 
     return NextResponse.json({
       ok: true,
@@ -94,6 +106,12 @@ export async function GET(request: Request, { params }: RouteContext) {
       .select('*', { count: 'exact', head: true })
       .eq('group_id', session.group_id),
   ]);
+  perf.step('latest_question_loaded');
+  perf.done({
+    mode: 'latest',
+    questionFound: Boolean(question?.id),
+    memberCount: memberCount ?? 0,
+  });
 
   return NextResponse.json({
     ok: true,

--- a/app/api/sessions/[sessionId]/runtime/route.ts
+++ b/app/api/sessions/[sessionId]/runtime/route.ts
@@ -10,7 +10,7 @@ export async function GET(request: Request, { params }: RouteContext) {
   const questionId = new URL(request.url).searchParams.get('questionId');
   const sessionId = params.sessionId;
 
-  if (!sessionId || !questionId) {
+  if (!sessionId) {
     return NextResponse.json({ ok: false }, { status: 400 });
   }
 
@@ -46,25 +46,40 @@ export async function GET(request: Request, { params }: RouteContext) {
     return NextResponse.json({ ok: false }, { status: 403 });
   }
 
-  const [{ data: question }, { count: submittedCount }, { count: memberCount }] = await Promise.all([
-    supabase
-      .schema('public')
-      .from('questions')
-      .select('id, phase, answer_deadline_at')
-      .eq('id', questionId)
-      .eq('session_id', sessionId)
-      .maybeSingle(),
-    supabase
-      .schema('public')
-      .from('answers')
-      .select('*', { count: 'exact', head: true })
-      .eq('question_id', questionId),
+  const questionQuery = questionId
+    ? supabase
+        .schema('public')
+        .from('questions')
+        .select('id, phase, answer_deadline_at')
+        .eq('id', questionId)
+        .eq('session_id', sessionId)
+        .maybeSingle()
+    : supabase
+        .schema('public')
+        .from('questions')
+        .select('id, phase, answer_deadline_at')
+        .eq('session_id', sessionId)
+        .not('launched_at', 'is', null)
+        .order('order_index', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+  const [{ data: question }, { count: memberCount }] = await Promise.all([
+    questionQuery,
     supabase
       .schema('public')
       .from('group_members')
       .select('*', { count: 'exact', head: true })
       .eq('group_id', session.group_id),
   ]);
+
+  const { count: submittedCount } = question?.id
+    ? await supabase
+        .schema('public')
+        .from('answers')
+        .select('*', { count: 'exact', head: true })
+        .eq('question_id', question.id)
+    : { count: 0 };
 
   return NextResponse.json({
     ok: true,

--- a/app/api/sessions/[sessionId]/runtime/route.ts
+++ b/app/api/sessions/[sessionId]/runtime/route.ts
@@ -46,26 +46,48 @@ export async function GET(request: Request, { params }: RouteContext) {
     return NextResponse.json({ ok: false }, { status: 403 });
   }
 
-  const questionQuery = questionId
-    ? supabase
+  if (questionId) {
+    const [{ data: question }, { count: memberCount }, { count: submittedCount }] = await Promise.all([
+      supabase
         .schema('public')
         .from('questions')
         .select('id, phase, answer_deadline_at')
         .eq('id', questionId)
         .eq('session_id', sessionId)
-        .maybeSingle()
-    : supabase
+        .maybeSingle(),
+      supabase
         .schema('public')
-        .from('questions')
-        .select('id, phase, answer_deadline_at')
-        .eq('session_id', sessionId)
-        .not('launched_at', 'is', null)
-        .order('order_index', { ascending: false })
-        .limit(1)
-        .maybeSingle();
+        .from('group_members')
+        .select('*', { count: 'exact', head: true })
+        .eq('group_id', session.group_id),
+      supabase
+        .schema('public')
+        .from('answers')
+        .select('*', { count: 'exact', head: true })
+        .eq('question_id', questionId),
+    ]);
+
+    return NextResponse.json({
+      ok: true,
+      sessionStatus: session.status,
+      questionId: question?.id ?? null,
+      questionPhase: question?.phase ?? null,
+      answerDeadlineAt: question?.answer_deadline_at ?? null,
+      submittedCount: submittedCount ?? 0,
+      memberCount: memberCount ?? 0,
+    });
+  }
 
   const [{ data: question }, { count: memberCount }] = await Promise.all([
-    questionQuery,
+    supabase
+      .schema('public')
+      .from('questions')
+      .select('id, phase, answer_deadline_at')
+      .eq('session_id', sessionId)
+      .not('launched_at', 'is', null)
+      .order('order_index', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
     supabase
       .schema('public')
       .from('group_members')
@@ -73,21 +95,13 @@ export async function GET(request: Request, { params }: RouteContext) {
       .eq('group_id', session.group_id),
   ]);
 
-  const { count: submittedCount } = question?.id
-    ? await supabase
-        .schema('public')
-        .from('answers')
-        .select('*', { count: 'exact', head: true })
-        .eq('question_id', question.id)
-    : { count: 0 };
-
   return NextResponse.json({
     ok: true,
     sessionStatus: session.status,
     questionId: question?.id ?? null,
     questionPhase: question?.phase ?? null,
     answerDeadlineAt: question?.answer_deadline_at ?? null,
-    submittedCount: submittedCount ?? 0,
+    submittedCount: 0,
     memberCount: memberCount ?? 0,
   });
 }

--- a/components/auth/logout-button.tsx
+++ b/components/auth/logout-button.tsx
@@ -5,7 +5,6 @@ import { useTransition } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 
-import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 import type { AppLocale } from '@/i18n/routing';
 import { cn } from '@/lib/utils';
 
@@ -25,8 +24,10 @@ export function LogoutButton({ className, showIcon = false }: LogoutButtonProps)
       type="button"
       onClick={() =>
         startTransition(async () => {
-          const supabase = createSupabaseBrowserClient();
-          await supabase.auth.signOut();
+          await fetch('/api/auth/logout', {
+            method: 'POST',
+            cache: 'no-store',
+          });
           router.push(`/${locale}/auth/login`);
           router.refresh();
         })

--- a/components/dashboard/dashboard-performance-view.tsx
+++ b/components/dashboard/dashboard-performance-view.tsx
@@ -137,9 +137,7 @@ export function DashboardPerformanceView({
           </div>
           <div className="text-right">
             <p className="text-[42px] font-extrabold leading-none text-brand">{completedSessionsCount}</p>
-            <p className="mt-2 text-sm font-semibold text-slate-500">
-              {labels.sessionsFinished.replace('{count}', String(completedSessionsCount))}
-            </p>
+            <p className="mt-2 text-sm font-semibold text-slate-500">{labels.sessionsFinished}</p>
           </div>
         </div>
 

--- a/components/dashboard/dashboard-performance-view.tsx
+++ b/components/dashboard/dashboard-performance-view.tsx
@@ -21,6 +21,7 @@ type SessionConfidenceBreakdownItem = {
 
 type DashboardPerformanceViewProps = {
   answeredCount: number;
+  completedSessionsCount: number;
   successRate: number | null;
   averageConfidence: 'low' | 'medium' | 'high' | null;
   heatmap: HeatmapDay[];
@@ -41,7 +42,9 @@ type DashboardPerformanceViewProps = {
     none: string;
     less: string;
     more: string;
+    sessionsFinished: string;
     averagePerWeek: string;
+    completion: string;
     confidenceCalibrationTitle: string;
   };
 };
@@ -86,6 +89,8 @@ function startOfUtcWeek(date: Date) {
 
 export function DashboardPerformanceView({
   answeredCount,
+  completedSessionsCount,
+  successRate,
   heatmap,
   confidenceCalibration,
   sessionConfidenceBreakdown,
@@ -128,6 +133,12 @@ export function DashboardPerformanceView({
             <p className="mt-2 text-2xl font-extrabold text-white">
               {answeredCount}
               <span className="ml-2 text-sm font-bold text-slate-500">{labels.questionsAnswered}</span>
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-[42px] font-extrabold leading-none text-brand">{completedSessionsCount}</p>
+            <p className="mt-2 text-sm font-semibold text-slate-500">
+              {labels.sessionsFinished.replace('{count}', String(completedSessionsCount))}
             </p>
           </div>
         </div>
@@ -185,6 +196,8 @@ export function DashboardPerformanceView({
             <div className="grid grid-cols-[1fr_auto] gap-x-5 gap-y-2 text-sm">
               <span className="font-semibold text-slate-500">{labels.averagePerWeek}</span>
               <span className="font-extrabold text-white">{averagePerWeek}</span>
+              <span className="font-semibold text-slate-500">{labels.completion}</span>
+              <span className="font-extrabold text-white">{successRate !== null ? `${successRate}%` : labels.noData}</span>
             </div>
           </aside>
         </div>

--- a/components/groups/group-page-view.tsx
+++ b/components/groups/group-page-view.tsx
@@ -61,8 +61,10 @@ type GroupPageViewProps = {
   isPrimaryGroupFounder: boolean;
   currentCaptainId: string | null;
   schedules: Schedule[];
-  weeklyCompletedQuestions: number;
-  weeklyTargetQuestions: number;
+  initialWeeklyProgress: {
+    weeklyCompletedQuestions: number;
+    weeklyTargetQuestions: number;
+  } | null;
   memberPerformance: MemberPerformance[];
   weekdayLabels: Record<string, string>;
   groupInfoSummary: string;
@@ -178,8 +180,7 @@ export function GroupPageView({
   isPrimaryGroupFounder,
   currentCaptainId,
   schedules,
-  weeklyCompletedQuestions,
-  weeklyTargetQuestions,
+  initialWeeklyProgress,
   memberPerformance,
   weekdayLabels,
   groupInfoSummary,
@@ -192,6 +193,13 @@ export function GroupPageView({
   const [resolvedShellGroups, setResolvedShellGroups] = useState(shellGroups);
   const [resolvedMemberPerformance, setResolvedMemberPerformance] = useState(memberPerformance);
   const [memberPerformanceLoaded, setMemberPerformanceLoaded] = useState(memberPerformance.length > 0);
+  const [weeklyProgress, setWeeklyProgress] = useState(
+    initialWeeklyProgress ?? {
+      weeklyCompletedQuestions: 0,
+      weeklyTargetQuestions: schedules.reduce((sum, schedule) => sum + schedule.question_goal, 0),
+    },
+  );
+  const [weeklyProgressLoaded, setWeeklyProgressLoaded] = useState(Boolean(initialWeeklyProgress));
   const groupPath = primaryGroup ? `/${locale}/groups/${primaryGroup.id}` : `/${locale}/groups`;
   const sessionGroupChoices =
     resolvedShellGroups.length > 0
@@ -231,6 +239,16 @@ export function GroupPageView({
   }, [locale, resolvedShellGroups.length]);
 
   useEffect(() => {
+    setWeeklyProgress(
+      initialWeeklyProgress ?? {
+        weeklyCompletedQuestions: 0,
+        weeklyTargetQuestions: schedules.reduce((sum, schedule) => sum + schedule.question_goal, 0),
+      },
+    );
+    setWeeklyProgressLoaded(Boolean(initialWeeklyProgress));
+  }, [initialWeeklyProgress, schedules]);
+
+  useEffect(() => {
     if (!primaryGroup || memberPerformanceLoaded) {
       return;
     }
@@ -254,6 +272,39 @@ export function GroupPageView({
       cancelled = true;
     };
   }, [memberPerformanceLoaded, primaryGroup]);
+
+  useEffect(() => {
+    if (!primaryGroup || weeklyProgressLoaded) {
+      return;
+    }
+
+    let cancelled = false;
+    fetch(`/api/groups/weekly-progress?groupId=${primaryGroup.id}`, { credentials: 'include' })
+      .then((response) => response.json())
+      .then((payload) => {
+        if (
+          !cancelled &&
+          payload?.ok &&
+          typeof payload.weeklyCompletedQuestions === 'number' &&
+          typeof payload.weeklyTargetQuestions === 'number'
+        ) {
+          setWeeklyProgress({
+            weeklyCompletedQuestions: payload.weeklyCompletedQuestions,
+            weeklyTargetQuestions: payload.weeklyTargetQuestions,
+          });
+          setWeeklyProgressLoaded(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setWeeklyProgressLoaded(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [primaryGroup, weeklyProgressLoaded]);
 
   return (
     <>
@@ -444,9 +495,13 @@ export function GroupPageView({
 
         <div className="mt-4 flex items-center justify-between border-t border-white/[0.06] pt-4 text-sm">
           <span className="font-semibold text-slate-500">{labels.weeklyTotal}</span>
-          <span className="font-extrabold text-white">
-            {weeklyCompletedQuestions} / {weeklyTargetQuestions || 100} Q
-          </span>
+          {weeklyProgressLoaded ? (
+            <span className="font-extrabold text-white">
+              {weeklyProgress.weeklyCompletedQuestions} / {weeklyProgress.weeklyTargetQuestions || 100} Q
+            </span>
+          ) : (
+            <span className="h-5 w-24 animate-pulse rounded bg-white/[0.06]" aria-hidden="true" />
+          )}
         </div>
       </section>
 

--- a/components/invite/switch-account-button.tsx
+++ b/components/invite/switch-account-button.tsx
@@ -1,9 +1,6 @@
 'use client';
 
 import { useTransition } from 'react';
-import { useRouter } from 'next/navigation';
-
-import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 
 type SwitchAccountButtonProps = {
   nextPath: string;
@@ -11,7 +8,6 @@ type SwitchAccountButtonProps = {
 };
 
 export function SwitchAccountButton({ nextPath, label }: SwitchAccountButtonProps) {
-  const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
   return (
@@ -19,10 +15,11 @@ export function SwitchAccountButton({ nextPath, label }: SwitchAccountButtonProp
       type="button"
       onClick={() =>
         startTransition(async () => {
-          const supabase = createSupabaseBrowserClient();
-          await supabase.auth.signOut();
+          await fetch('/api/auth/logout', {
+            method: 'POST',
+            cache: 'no-store',
+          });
           window.location.assign(nextPath);
-          router.refresh();
         })
       }
       className="button-primary mt-6 inline-flex h-12 items-center justify-center rounded-[8px] px-5 text-sm"

--- a/components/layout/language-switcher.tsx
+++ b/components/layout/language-switcher.tsx
@@ -5,14 +5,17 @@ import { useMemo, useTransition } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
 
+import { usePathname, useRouter } from '@/i18n/navigation';
 import { routing, type AppLocale } from '@/i18n/routing';
 
 export function LanguageSwitcher() {
   const t = useTranslations('Common');
   const locale = useLocale() as AppLocale;
+  const pathname = usePathname();
+  const router = useRouter();
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
-  const search = useMemo(() => searchParams.toString(), [searchParams]);
+  const query = useMemo(() => Object.fromEntries(searchParams.entries()), [searchParams]);
   const nextLocale = locale === 'en' ? 'fr' : 'en';
   const displayedLocale = routing.locales.length === 2 ? nextLocale : locale;
 
@@ -21,10 +24,13 @@ export function LanguageSwitcher() {
       type="button"
       onClick={() => {
         startTransition(() => {
-          const currentPath = window.location.pathname;
-          const localizedPath = currentPath.replace(/^\/(en|fr)(?=\/|$)/, `/${nextLocale}`);
-          const nextPath = search ? `${localizedPath}?${search}` : localizedPath;
-          window.location.assign(nextPath);
+          router.replace(
+            {
+              pathname,
+              query,
+            },
+            { locale: nextLocale },
+          );
         });
       }}
       className="inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm font-medium text-slate-300 transition hover:bg-white/[0.04] hover:text-white"

--- a/components/onboarding/landing-signup-modal.tsx
+++ b/components/onboarding/landing-signup-modal.tsx
@@ -1,9 +1,8 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import { X } from 'lucide-react';
 import { useEffect, useState } from 'react';
-
-import { AuthForm } from '@/components/auth/auth-form';
 
 type LandingSignupModalProps = {
   locale: string;
@@ -11,6 +10,11 @@ type LandingSignupModalProps = {
   className?: string;
   closeLabel: string;
 };
+
+const AuthForm = dynamic(() => import('@/components/auth/auth-form').then((module) => module.AuthForm), {
+  ssr: false,
+  loading: () => <div className="h-[520px] animate-pulse rounded-[6px] bg-white/[0.03]" aria-hidden="true" />,
+});
 
 export function LandingSignupModal({ locale, children, className, closeLabel }: LandingSignupModalProps) {
   const [open, setOpen] = useState(false);

--- a/components/session/runtime-client.ts
+++ b/components/session/runtime-client.ts
@@ -1,0 +1,52 @@
+'use client';
+
+type RuntimePayload = {
+  ok: boolean;
+  sessionStatus: string;
+  questionId: string | null;
+  questionPhase: string | null;
+  answerDeadlineAt?: string | null;
+  submittedCount?: number;
+  memberCount?: number;
+};
+
+const inflightRuntimeRequests = new Map<string, Promise<RuntimePayload | null>>();
+const recentRuntimeResponses = new Map<string, { payload: RuntimePayload; expiresAt: number }>();
+const RECENT_RESPONSE_TTL_MS = 500;
+
+export async function fetchSessionRuntime(url: string): Promise<RuntimePayload | null> {
+  const now = Date.now();
+  const cached = recentRuntimeResponses.get(url);
+  if (cached && cached.expiresAt > now) {
+    return cached.payload;
+  }
+
+  const existing = inflightRuntimeRequests.get(url);
+  if (existing) {
+    return existing;
+  }
+
+  const request = fetch(url, {
+    cache: 'no-store',
+    credentials: 'same-origin',
+  })
+    .then(async (response) => {
+      if (!response.ok) {
+        return null;
+      }
+
+      const payload = (await response.json()) as RuntimePayload;
+      recentRuntimeResponses.set(url, {
+        payload,
+        expiresAt: Date.now() + RECENT_RESPONSE_TTL_MS,
+      });
+      return payload;
+    })
+    .catch(() => null)
+    .finally(() => {
+      inflightRuntimeRequests.delete(url);
+    });
+
+  inflightRuntimeRequests.set(url, request);
+  return request;
+}

--- a/components/session/session-active-runtime.tsx
+++ b/components/session/session-active-runtime.tsx
@@ -72,12 +72,14 @@ export function SessionActiveRuntime({
   const [submittedCount, setSubmittedCount] = useState(initialSubmittedCount);
   const [memberCount, setMemberCount] = useState(initialMemberCount);
   const [answerDeadlineAt, setAnswerDeadlineAt] = useState(initialAnswerDeadlineAt);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const refreshInFlightRef = useRef(false);
 
   useEffect(() => {
     setSubmittedCount(initialSubmittedCount);
     setMemberCount(initialMemberCount);
     setAnswerDeadlineAt(initialAnswerDeadlineAt);
+    setIsSubmitting(false);
     refreshInFlightRef.current = false;
   }, [initialAnswerDeadlineAt, initialMemberCount, initialSubmittedCount, questionId]);
 
@@ -86,7 +88,7 @@ export function SessionActiveRuntime({
     let intervalId: number | null = null;
 
     const syncRuntime = async () => {
-      if (document.visibilityState !== 'visible' || refreshInFlightRef.current) {
+      if (document.visibilityState !== 'visible' || refreshInFlightRef.current || isSubmitting) {
         return;
       }
 
@@ -157,7 +159,7 @@ export function SessionActiveRuntime({
         window.clearInterval(intervalId);
       }
     };
-  }, [questionId, router, sessionId]);
+  }, [isSubmitting, questionId, router, sessionId]);
 
   return (
     <>
@@ -192,6 +194,7 @@ export function SessionActiveRuntime({
           answerDeadlineAt={answerDeadlineAt}
           submittedCount={submittedCount}
           memberCount={memberCount}
+          onSubmissionStateChange={setIsSubmitting}
           labels={{
             confidenceTitle: labels.confidenceTitle,
             confidenceLow: labels.confidenceLow,

--- a/components/session/session-active-runtime.tsx
+++ b/components/session/session-active-runtime.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { SessionAnswerForm, SessionHeaderMeta } from '@/components/session/session-flow-client';
+import { Link } from '@/i18n/navigation';
+import type { ConfidenceLevel } from '@/lib/demo/confidence';
+
+type ServerAction = (formData: FormData) => void | Promise<void>;
+
+type SessionActiveRuntimeProps = {
+  sessionId: string;
+  questionId: string;
+  questionIndex: number;
+  questionGoal: number;
+  initialSubmittedCount: number;
+  initialMemberCount: number;
+  initialAnswerDeadlineAt: string | null;
+  initialAnswer?: string | null;
+  initialConfidence?: ConfidenceLevel | null;
+  locale: string;
+  labels: {
+    questionUpper: string;
+    confidenceTitle: string;
+    confidenceLow: string;
+    confidenceMedium: string;
+    confidenceHigh: string;
+    customOptionLabel: string;
+    customOptionPlaceholder: string;
+    submit: string;
+    submitPending: string;
+    nextQuestion: string;
+    nextQuestionPending: string;
+    allAnswersReceived: string;
+  };
+  action: ServerAction;
+  timeoutAction: ServerAction;
+  advanceAction: ServerAction;
+};
+
+type RuntimePayload = {
+  ok: boolean;
+  sessionStatus: string;
+  questionId: string | null;
+  questionPhase: string | null;
+  answerDeadlineAt: string | null;
+  submittedCount: number;
+  memberCount: number;
+};
+
+const POLL_INTERVAL_MS = 1800;
+
+export function SessionActiveRuntime({
+  sessionId,
+  questionId,
+  questionIndex,
+  questionGoal,
+  initialSubmittedCount,
+  initialMemberCount,
+  initialAnswerDeadlineAt,
+  initialAnswer,
+  initialConfidence,
+  locale,
+  labels,
+  action,
+  timeoutAction,
+  advanceAction,
+}: SessionActiveRuntimeProps) {
+  const router = useRouter();
+  const [submittedCount, setSubmittedCount] = useState(initialSubmittedCount);
+  const [memberCount, setMemberCount] = useState(initialMemberCount);
+  const [answerDeadlineAt, setAnswerDeadlineAt] = useState(initialAnswerDeadlineAt);
+  const refreshInFlightRef = useRef(false);
+
+  useEffect(() => {
+    setSubmittedCount(initialSubmittedCount);
+    setMemberCount(initialMemberCount);
+    setAnswerDeadlineAt(initialAnswerDeadlineAt);
+    refreshInFlightRef.current = false;
+  }, [initialAnswerDeadlineAt, initialMemberCount, initialSubmittedCount, questionId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let intervalId: number | null = null;
+
+    const syncRuntime = async () => {
+      if (document.visibilityState !== 'visible' || refreshInFlightRef.current) {
+        return;
+      }
+
+      refreshInFlightRef.current = true;
+
+      try {
+        const response = await fetch(`/api/sessions/${sessionId}/runtime?questionId=${encodeURIComponent(questionId)}`, {
+          cache: 'no-store',
+          credentials: 'same-origin',
+        });
+
+        if (!response.ok || cancelled) {
+          return;
+        }
+
+        const payload = (await response.json()) as RuntimePayload;
+
+        if (
+          payload.sessionStatus !== 'active' ||
+          payload.questionId !== questionId ||
+          payload.questionPhase !== 'answering'
+        ) {
+          router.refresh();
+          return;
+        }
+
+        setSubmittedCount(payload.submittedCount);
+        setMemberCount(Math.max(payload.memberCount, 1));
+        setAnswerDeadlineAt(payload.answerDeadlineAt);
+      } catch {
+        // Keep the current UI state and wait for the next sync attempt.
+      } finally {
+        refreshInFlightRef.current = false;
+      }
+    };
+
+    const startPolling = () => {
+      if (intervalId !== null) {
+        window.clearInterval(intervalId);
+      }
+
+      if (document.visibilityState !== 'visible') {
+        intervalId = null;
+        return;
+      }
+
+      intervalId = window.setInterval(() => {
+        void syncRuntime();
+      }, POLL_INTERVAL_MS);
+    };
+
+    void syncRuntime();
+    startPolling();
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        void syncRuntime();
+      }
+      startPolling();
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      if (intervalId !== null) {
+        window.clearInterval(intervalId);
+      }
+    };
+  }, [questionId, router, sessionId]);
+
+  return (
+    <>
+      <header className="border-b border-white/[0.07]">
+        <div className="mx-auto flex min-h-16 w-full max-w-[560px] items-center justify-between gap-3 px-4 py-3 sm:h-16 sm:py-0">
+          <Link href="/dashboard?view=sessions" prefetch={false} className="text-slate-500 hover:text-white">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+          </Link>
+          <div className="text-center">
+            <p className="text-xs font-bold uppercase tracking-[0.18em] text-slate-500">{labels.questionUpper}</p>
+            <p className="text-xl font-extrabold text-white">
+              {questionIndex + 1}
+              <span className="text-sm text-slate-500">/{questionGoal}</span>
+            </p>
+          </div>
+          <SessionHeaderMeta submittedCount={submittedCount} memberCount={memberCount} answerDeadlineAt={answerDeadlineAt} />
+        </div>
+      </header>
+
+      <section className="mx-auto w-full max-w-[560px] px-4 py-7">
+        <SessionAnswerForm
+          key={questionId}
+          action={action}
+          timeoutAction={timeoutAction}
+          advanceAction={advanceAction}
+          locale={locale}
+          sessionId={sessionId}
+          questionId={questionId}
+          questionIndex={questionIndex}
+          initialAnswer={initialAnswer}
+          initialConfidence={initialConfidence}
+          answerDeadlineAt={answerDeadlineAt}
+          submittedCount={submittedCount}
+          memberCount={memberCount}
+          labels={{
+            confidenceTitle: labels.confidenceTitle,
+            confidenceLow: labels.confidenceLow,
+            confidenceMedium: labels.confidenceMedium,
+            confidenceHigh: labels.confidenceHigh,
+            customOptionLabel: labels.customOptionLabel,
+            customOptionPlaceholder: labels.customOptionPlaceholder,
+            submit: labels.submit,
+            submitPending: labels.submitPending,
+            nextQuestion: labels.nextQuestion,
+            nextQuestionPending: labels.nextQuestionPending,
+            allAnswersReceived: labels.allAnswersReceived,
+          }}
+        />
+      </section>
+    </>
+  );
+}

--- a/components/session/session-active-runtime.tsx
+++ b/components/session/session-active-runtime.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
+import { fetchSessionRuntime } from '@/components/session/runtime-client';
 import { SessionAnswerForm, SessionHeaderMeta } from '@/components/session/session-flow-client';
 import { Link } from '@/i18n/navigation';
 import type { ConfidenceLevel } from '@/lib/demo/confidence';
@@ -35,22 +36,12 @@ type SessionActiveRuntimeProps = {
     nextQuestionPending: string;
     allAnswersReceived: string;
   };
-  action: ServerAction;
-  timeoutAction: ServerAction;
   advanceAction: ServerAction;
 };
 
-type RuntimePayload = {
-  ok: boolean;
-  sessionStatus: string;
-  questionId: string | null;
-  questionPhase: string | null;
-  answerDeadlineAt: string | null;
-  submittedCount: number;
-  memberCount: number;
-};
-
-const POLL_INTERVAL_MS = 1800;
+const BASE_POLL_INTERVAL_MS = 1800;
+const ANSWERED_POLL_INTERVAL_MS = 2600;
+const READY_POLL_INTERVAL_MS = 900;
 
 export function SessionActiveRuntime({
   sessionId,
@@ -64,28 +55,62 @@ export function SessionActiveRuntime({
   initialConfidence,
   locale,
   labels,
-  action,
-  timeoutAction,
   advanceAction,
 }: SessionActiveRuntimeProps) {
   const router = useRouter();
   const [submittedCount, setSubmittedCount] = useState(initialSubmittedCount);
   const [memberCount, setMemberCount] = useState(initialMemberCount);
   const [answerDeadlineAt, setAnswerDeadlineAt] = useState(initialAnswerDeadlineAt);
+  const [currentAnswer, setCurrentAnswer] = useState(initialAnswer ?? null);
+  const [currentConfidence, setCurrentConfidence] = useState(initialConfidence ?? null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const refreshInFlightRef = useRef(false);
+  const answeredLocallyRef = useRef(Boolean(initialAnswer));
+  const submittedCountRef = useRef(initialSubmittedCount);
+  const memberCountRef = useRef(initialMemberCount);
+  const currentAnswerRef = useRef<string | null>(initialAnswer ?? null);
 
   useEffect(() => {
     setSubmittedCount(initialSubmittedCount);
     setMemberCount(initialMemberCount);
     setAnswerDeadlineAt(initialAnswerDeadlineAt);
+    setCurrentAnswer(initialAnswer ?? null);
+    setCurrentConfidence(initialConfidence ?? null);
     setIsSubmitting(false);
     refreshInFlightRef.current = false;
-  }, [initialAnswerDeadlineAt, initialMemberCount, initialSubmittedCount, questionId]);
+    answeredLocallyRef.current = Boolean(initialAnswer);
+    submittedCountRef.current = initialSubmittedCount;
+    memberCountRef.current = initialMemberCount;
+    currentAnswerRef.current = initialAnswer ?? null;
+  }, [initialAnswer, initialAnswerDeadlineAt, initialConfidence, initialMemberCount, initialSubmittedCount, questionId]);
+
+  useEffect(() => {
+    submittedCountRef.current = submittedCount;
+  }, [submittedCount]);
+
+  useEffect(() => {
+    memberCountRef.current = memberCount;
+  }, [memberCount]);
+
+  useEffect(() => {
+    currentAnswerRef.current = currentAnswer;
+  }, [currentAnswer]);
 
   useEffect(() => {
     let cancelled = false;
-    let intervalId: number | null = null;
+    let timeoutId: number | null = null;
+
+    const getPollDelay = () => {
+      if (submittedCountRef.current >= Math.max(memberCountRef.current, 1)) {
+        return READY_POLL_INTERVAL_MS;
+      }
+
+      if (currentAnswerRef.current) {
+        return ANSWERED_POLL_INTERVAL_MS;
+      }
+
+      return BASE_POLL_INTERVAL_MS;
+    };
 
     const syncRuntime = async () => {
       if (document.visibilityState !== 'visible' || refreshInFlightRef.current || isSubmitting) {
@@ -95,16 +120,13 @@ export function SessionActiveRuntime({
       refreshInFlightRef.current = true;
 
       try {
-        const response = await fetch(`/api/sessions/${sessionId}/runtime?questionId=${encodeURIComponent(questionId)}`, {
-          cache: 'no-store',
-          credentials: 'same-origin',
-        });
+        const payload = await fetchSessionRuntime(
+          `/api/sessions/${sessionId}/runtime?questionId=${encodeURIComponent(questionId)}`,
+        );
 
-        if (!response.ok || cancelled) {
+        if (!payload || cancelled) {
           return;
         }
-
-        const payload = (await response.json()) as RuntimePayload;
 
         if (
           payload.sessionStatus !== 'active' ||
@@ -115,9 +137,9 @@ export function SessionActiveRuntime({
           return;
         }
 
-        setSubmittedCount(payload.submittedCount);
-        setMemberCount(Math.max(payload.memberCount, 1));
-        setAnswerDeadlineAt(payload.answerDeadlineAt);
+        setSubmittedCount(payload.submittedCount ?? 0);
+        setMemberCount(Math.max(payload.memberCount ?? 0, 1));
+        setAnswerDeadlineAt(payload.answerDeadlineAt ?? null);
       } catch {
         // Keep the current UI state and wait for the next sync attempt.
       } finally {
@@ -126,18 +148,22 @@ export function SessionActiveRuntime({
     };
 
     const startPolling = () => {
-      if (intervalId !== null) {
-        window.clearInterval(intervalId);
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
       }
 
       if (document.visibilityState !== 'visible') {
-        intervalId = null;
+        timeoutId = null;
         return;
       }
 
-      intervalId = window.setInterval(() => {
-        void syncRuntime();
-      }, POLL_INTERVAL_MS);
+      timeoutId = window.setTimeout(() => {
+        void syncRuntime().finally(() => {
+          if (!cancelled) {
+            startPolling();
+          }
+        });
+      }, getPollDelay());
     };
 
     void syncRuntime();
@@ -155,8 +181,8 @@ export function SessionActiveRuntime({
     return () => {
       cancelled = true;
       document.removeEventListener('visibilitychange', handleVisibilityChange);
-      if (intervalId !== null) {
-        window.clearInterval(intervalId);
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
       }
     };
   }, [isSubmitting, questionId, router, sessionId]);
@@ -182,19 +208,31 @@ export function SessionActiveRuntime({
       <section className="mx-auto w-full max-w-[560px] px-4 py-7">
         <SessionAnswerForm
           key={questionId}
-          action={action}
-          timeoutAction={timeoutAction}
           advanceAction={advanceAction}
           locale={locale}
           sessionId={sessionId}
           questionId={questionId}
           questionIndex={questionIndex}
-          initialAnswer={initialAnswer}
-          initialConfidence={initialConfidence}
+          initialAnswer={currentAnswer}
+          initialConfidence={currentConfidence}
           answerDeadlineAt={answerDeadlineAt}
           submittedCount={submittedCount}
           memberCount={memberCount}
           onSubmissionStateChange={setIsSubmitting}
+          onAnswerPersisted={(savedAnswer, savedConfidence) => {
+            if (!answeredLocallyRef.current) {
+              answeredLocallyRef.current = true;
+              setSubmittedCount((current) => {
+                const nextCount = Math.min(Math.max(memberCount, 1), current + 1);
+                submittedCountRef.current = nextCount;
+                return nextCount;
+              });
+            }
+            setCurrentAnswer(savedAnswer);
+            setCurrentConfidence(savedConfidence);
+            currentAnswerRef.current = savedAnswer;
+            setIsSubmitting(false);
+          }}
           labels={{
             confidenceTitle: labels.confidenceTitle,
             confidenceLow: labels.confidenceLow,

--- a/components/session/session-flow-client.tsx
+++ b/components/session/session-flow-client.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Check, Clock, Users } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 import { SubmitButton } from '@/components/ui/submit-button';
 import {
@@ -13,6 +14,13 @@ import {
 import { ANSWER_OPTIONS, type AnswerOption } from '@/lib/types/demo';
 
 type ServerAction = (formData: FormData) => void | Promise<void>;
+type SubmitAnswerResponse = {
+  ok: boolean;
+  message?: string;
+  redirectTo?: string;
+  selectedOption?: string | null;
+  confidence?: ConfidenceLevel | null;
+};
 
 function isCustomLetter(value: string) {
   return /^[A-Z]$/.test(value) && !ANSWER_OPTIONS.includes(value as AnswerOption);
@@ -57,8 +65,6 @@ export function SessionHeaderMeta({
 }
 
 export function SessionAnswerForm({
-  action,
-  timeoutAction,
   advanceAction,
   locale,
   sessionId,
@@ -70,10 +76,9 @@ export function SessionAnswerForm({
   submittedCount,
   memberCount,
   onSubmissionStateChange,
+  onAnswerPersisted,
   labels,
 }: {
-  action: ServerAction;
-  timeoutAction: ServerAction;
   advanceAction: ServerAction;
   locale: string;
   sessionId: string;
@@ -85,6 +90,7 @@ export function SessionAnswerForm({
   submittedCount: number;
   memberCount: number;
   onSubmissionStateChange?: (isSubmitting: boolean) => void;
+  onAnswerPersisted?: (selectedOption: string, confidence: ConfidenceLevel | null) => void;
   labels: {
     confidenceTitle: string;
     confidenceLow: string;
@@ -99,6 +105,8 @@ export function SessionAnswerForm({
     allAnswersReceived: string;
   };
 }) {
+  const router = useRouter();
+  const [isHydrated, setIsHydrated] = useState(false);
   const initialSelectedOption =
     initialAnswer && !ANSWER_OPTIONS.includes(initialAnswer as AnswerOption) && initialAnswer !== '?'
       ? '?'
@@ -113,9 +121,10 @@ export function SessionAnswerForm({
   const [remainingSeconds, setRemainingSeconds] = useState(() =>
     answerDeadlineAt ? Math.max(0, Math.ceil((new Date(answerDeadlineAt).getTime() - Date.now()) / 1000)) : 0,
   );
-  const timeoutFormRef = useRef<HTMLFormElement>(null);
   const customOptionInputRef = useRef<HTMLInputElement>(null);
   const timeoutSubmittedRef = useRef(false);
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(false);
   const hasAnswer = Boolean(initialAnswer);
   const isExpired = remainingSeconds <= 0;
   const hasAllAnswers = submittedCount >= memberCount || isExpired;
@@ -125,6 +134,10 @@ export function SessionAnswerForm({
     (selectedOption !== '?' || isCustomLetter(normalizedCustomOption)) &&
     !hasAnswer &&
     !isExpired;
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
 
   useEffect(() => {
     setSelectedOption(
@@ -141,6 +154,8 @@ export function SessionAnswerForm({
     setRemainingSeconds(
       answerDeadlineAt ? Math.max(0, Math.ceil((new Date(answerDeadlineAt).getTime() - Date.now()) / 1000)) : 0,
     );
+    setSubmissionError(null);
+    setIsPending(false);
     timeoutSubmittedRef.current = false;
   }, [answerDeadlineAt, initialAnswer, initialConfidence, questionId]);
 
@@ -149,6 +164,64 @@ export function SessionAnswerForm({
       onSubmissionStateChange?.(false);
     }
   }, [hasAnswer, onSubmissionStateChange, questionId]);
+
+  const submitAnswer = useCallback(async (mode: 'submit' | 'timeout') => {
+    setSubmissionError(null);
+    setIsPending(true);
+    onSubmissionStateChange?.(true);
+
+    try {
+      const response = await fetch(`/api/sessions/${sessionId}/answer`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          locale,
+          sessionId,
+          questionId,
+          questionIndex,
+          selectedOption,
+          customOption: normalizedCustomOption,
+          confidence,
+          mode,
+        }),
+      });
+
+      const payload = (await response.json().catch(() => ({ ok: false }))) as SubmitAnswerResponse;
+
+      if (!response.ok || !payload.ok) {
+        if (payload.redirectTo) {
+          router.replace(payload.redirectTo as never);
+          return;
+        }
+
+        setSubmissionError(payload.message ?? labels.submitPending);
+        setIsPending(false);
+        onSubmissionStateChange?.(false);
+        return;
+      }
+
+      onAnswerPersisted?.(payload.selectedOption ?? '?', payload.confidence ?? null);
+    } catch {
+      setSubmissionError(labels.submitPending);
+      setIsPending(false);
+      onSubmissionStateChange?.(false);
+    }
+  }, [
+    confidence,
+    labels.submitPending,
+    locale,
+    normalizedCustomOption,
+    onAnswerPersisted,
+    onSubmissionStateChange,
+    questionId,
+    questionIndex,
+    router,
+    selectedOption,
+    sessionId,
+  ]);
 
   useEffect(() => {
     if (selectedOption === '?' && !hasAnswer && !isExpired) {
@@ -165,15 +238,14 @@ export function SessionAnswerForm({
       setRemainingSeconds(nextRemaining);
       if (nextRemaining <= 0 && !hasAnswer && !timeoutSubmittedRef.current) {
         timeoutSubmittedRef.current = true;
-        onSubmissionStateChange?.(true);
-        timeoutFormRef.current?.requestSubmit();
+        void submitAnswer('timeout');
       }
     };
 
     tick();
     const id = window.setInterval(tick, 1000);
     return () => window.clearInterval(id);
-  }, [answerDeadlineAt, hasAnswer, onSubmissionStateChange]);
+  }, [answerDeadlineAt, hasAnswer, submitAnswer]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -230,12 +302,6 @@ export function SessionAnswerForm({
 
   return (
     <div className="mx-auto w-full max-w-[496px] space-y-7">
-      <form ref={timeoutFormRef} action={timeoutAction}>
-        <input type="hidden" name="locale" value={locale} />
-        <input type="hidden" name="sessionId" value={sessionId} />
-        <input type="hidden" name="questionIndex" value={questionIndex} />
-      </form>
-
       <div className="grid grid-cols-3 gap-2 min-[420px]:grid-cols-6">
         {[...ANSWER_OPTIONS, '?'].map((option) => (
           <label
@@ -259,7 +325,7 @@ export function SessionAnswerForm({
                   setCustomOption('');
                 }
               }}
-              disabled={hasAnswer || isExpired}
+              disabled={hasAnswer || isExpired || isPending}
               className="sr-only"
             />
             {option}
@@ -287,7 +353,7 @@ export function SessionAnswerForm({
               const nextValue = event.target.value.replace(/[^a-z]/gi, '').slice(-1).toUpperCase();
               setCustomOption(ANSWER_OPTIONS.includes(nextValue as AnswerOption) ? '' : nextValue);
             }}
-            disabled={hasAnswer || isExpired}
+            disabled={hasAnswer || isExpired || isPending}
             placeholder={labels.customOptionPlaceholder}
             className="field w-full rounded-[7px] text-center text-lg font-extrabold uppercase tracking-[0.12em]"
           />
@@ -320,7 +386,7 @@ export function SessionAnswerForm({
                 value={value}
                 checked={confidence === value}
                 onChange={() => setConfidence(value as ConfidenceLevel)}
-                disabled={hasAnswer || isExpired}
+                disabled={hasAnswer || isExpired || isPending}
                 className="sr-only"
               />
               {label}
@@ -330,24 +396,27 @@ export function SessionAnswerForm({
       </div>
 
       {!hasAnswer && canSubmit ? (
-        <form
-          action={action}
-          onSubmitCapture={() => {
-            onSubmissionStateChange?.(true);
+        <button
+          type="button"
+          disabled={isPending || !isHydrated}
+          onClick={() => {
+            void submitAnswer('submit');
           }}
+          className="button-primary relative h-16 w-full rounded-[7px] text-base disabled:cursor-not-allowed disabled:opacity-70"
+          aria-disabled={isPending || !isHydrated}
+          aria-busy={isPending}
         >
-          <input type="hidden" name="locale" value={locale} />
-          <input type="hidden" name="sessionId" value={sessionId} />
-          <input type="hidden" name="questionId" value={questionId} />
-          <input type="hidden" name="questionIndex" value={questionIndex} />
-          <input type="hidden" name="selectedOption" value={selectedOption} />
-          <input type="hidden" name="customOption" value={normalizedCustomOption} />
-          <input type="hidden" name="confidence" value={confidence} />
-          <SubmitButton pendingLabel={labels.submitPending} className="button-primary h-16 w-full rounded-[7px] text-base">
-            {labels.submit}
-          </SubmitButton>
-        </form>
+          <span className={isPending ? 'text-transparent' : ''}>{labels.submit}</span>
+          {isPending ? (
+            <span className="absolute inset-0 inline-flex items-center justify-center gap-2">
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
+              {labels.submitPending}
+            </span>
+          ) : null}
+        </button>
       ) : null}
+
+      {submissionError ? <p className="text-center text-sm font-bold text-red-400">{submissionError}</p> : null}
 
       {hasAllAnswers ? (
         <>

--- a/components/session/session-flow-client.tsx
+++ b/components/session/session-flow-client.tsx
@@ -2,7 +2,6 @@
 
 import { Check, Clock, Users } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
-import { useRouter } from 'next/navigation';
 
 import { SubmitButton } from '@/components/ui/submit-button';
 import {
@@ -112,7 +111,6 @@ export function SessionAnswerForm({
   const [remainingSeconds, setRemainingSeconds] = useState(() =>
     answerDeadlineAt ? Math.max(0, Math.ceil((new Date(answerDeadlineAt).getTime() - Date.now()) / 1000)) : 0,
   );
-  const router = useRouter();
   const timeoutFormRef = useRef<HTMLFormElement>(null);
   const customOptionInputRef = useRef<HTMLInputElement>(null);
   const timeoutSubmittedRef = useRef(false);
@@ -167,14 +165,6 @@ export function SessionAnswerForm({
     const id = window.setInterval(tick, 1000);
     return () => window.clearInterval(id);
   }, [answerDeadlineAt, hasAnswer]);
-
-  useEffect(() => {
-    if (!hasAnswer || hasAllAnswers) return undefined;
-    const id = window.setInterval(() => {
-      router.refresh();
-    }, 1200);
-    return () => window.clearInterval(id);
-  }, [hasAnswer, hasAllAnswers, router]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/components/session/session-flow-client.tsx
+++ b/components/session/session-flow-client.tsx
@@ -69,6 +69,7 @@ export function SessionAnswerForm({
   answerDeadlineAt,
   submittedCount,
   memberCount,
+  onSubmissionStateChange,
   labels,
 }: {
   action: ServerAction;
@@ -83,6 +84,7 @@ export function SessionAnswerForm({
   answerDeadlineAt: string | null;
   submittedCount: number;
   memberCount: number;
+  onSubmissionStateChange?: (isSubmitting: boolean) => void;
   labels: {
     confidenceTitle: string;
     confidenceLow: string;
@@ -143,6 +145,12 @@ export function SessionAnswerForm({
   }, [answerDeadlineAt, initialAnswer, initialConfidence, questionId]);
 
   useEffect(() => {
+    if (!hasAnswer) {
+      onSubmissionStateChange?.(false);
+    }
+  }, [hasAnswer, onSubmissionStateChange, questionId]);
+
+  useEffect(() => {
     if (selectedOption === '?' && !hasAnswer && !isExpired) {
       customOptionInputRef.current?.focus();
       customOptionInputRef.current?.select();
@@ -157,6 +165,7 @@ export function SessionAnswerForm({
       setRemainingSeconds(nextRemaining);
       if (nextRemaining <= 0 && !hasAnswer && !timeoutSubmittedRef.current) {
         timeoutSubmittedRef.current = true;
+        onSubmissionStateChange?.(true);
         timeoutFormRef.current?.requestSubmit();
       }
     };
@@ -164,7 +173,7 @@ export function SessionAnswerForm({
     tick();
     const id = window.setInterval(tick, 1000);
     return () => window.clearInterval(id);
-  }, [answerDeadlineAt, hasAnswer]);
+  }, [answerDeadlineAt, hasAnswer, onSubmissionStateChange]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -321,7 +330,12 @@ export function SessionAnswerForm({
       </div>
 
       {!hasAnswer && canSubmit ? (
-        <form action={action}>
+        <form
+          action={action}
+          onSubmitCapture={() => {
+            onSubmissionStateChange?.(true);
+          }}
+        >
           <input type="hidden" name="locale" value={locale} />
           <input type="hidden" name="sessionId" value={sessionId} />
           <input type="hidden" name="questionId" value={questionId} />
@@ -338,7 +352,12 @@ export function SessionAnswerForm({
       {hasAllAnswers ? (
         <>
           <div className="text-center text-sm font-bold text-brand">{labels.allAnswersReceived}</div>
-          <form action={advanceAction}>
+          <form
+            action={advanceAction}
+            onSubmitCapture={() => {
+              onSubmissionStateChange?.(true);
+            }}
+          >
             <input type="hidden" name="locale" value={locale} />
             <input type="hidden" name="sessionId" value={sessionId} />
             <input type="hidden" name="questionIndex" value={questionIndex} />

--- a/components/session/session-stage-refresh.tsx
+++ b/components/session/session-stage-refresh.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+
+type SessionStageRefreshProps = {
+  sessionId: string;
+  expectedStatus: string;
+  expectedQuestionId?: string | null;
+};
+
+type RuntimePayload = {
+  ok: boolean;
+  sessionStatus: string;
+  questionId: string | null;
+  questionPhase: string | null;
+};
+
+const POLL_INTERVAL_MS = 2000;
+
+export function SessionStageRefresh({
+  sessionId,
+  expectedStatus,
+  expectedQuestionId = null,
+}: SessionStageRefreshProps) {
+  const router = useRouter();
+  const refreshInFlightRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    let intervalId: number | null = null;
+
+    const syncStage = async () => {
+      if (document.visibilityState !== 'visible' || refreshInFlightRef.current) {
+        return;
+      }
+
+      refreshInFlightRef.current = true;
+
+      try {
+        const response = await fetch(`/api/sessions/${sessionId}/runtime`, {
+          cache: 'no-store',
+          credentials: 'same-origin',
+        });
+
+        if (!response.ok || cancelled) {
+          return;
+        }
+
+        const payload = (await response.json()) as RuntimePayload;
+        const statusChanged = payload.sessionStatus !== expectedStatus;
+        const questionChanged = payload.questionId !== expectedQuestionId;
+
+        if (statusChanged || questionChanged) {
+          router.refresh();
+        }
+      } catch {
+        // Ignore transient polling failures and retry on the next interval.
+      } finally {
+        refreshInFlightRef.current = false;
+      }
+    };
+
+    const startPolling = () => {
+      if (intervalId !== null) {
+        window.clearInterval(intervalId);
+      }
+
+      if (document.visibilityState !== 'visible') {
+        intervalId = null;
+        return;
+      }
+
+      intervalId = window.setInterval(() => {
+        void syncStage();
+      }, POLL_INTERVAL_MS);
+    };
+
+    void syncStage();
+    startPolling();
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        void syncStage();
+      }
+      startPolling();
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      if (intervalId !== null) {
+        window.clearInterval(intervalId);
+      }
+    };
+  }, [expectedQuestionId, expectedStatus, router, sessionId]);
+
+  return null;
+}

--- a/components/session/session-stage-refresh.tsx
+++ b/components/session/session-stage-refresh.tsx
@@ -3,20 +3,15 @@
 import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 
+import { fetchSessionRuntime } from '@/components/session/runtime-client';
+
 type SessionStageRefreshProps = {
   sessionId: string;
   expectedStatus: string;
   expectedQuestionId?: string | null;
 };
 
-type RuntimePayload = {
-  ok: boolean;
-  sessionStatus: string;
-  questionId: string | null;
-  questionPhase: string | null;
-};
-
-const POLL_INTERVAL_MS = 2000;
+const POLL_INTERVAL_MS = 2400;
 
 export function SessionStageRefresh({
   sessionId,
@@ -38,16 +33,11 @@ export function SessionStageRefresh({
       refreshInFlightRef.current = true;
 
       try {
-        const response = await fetch(`/api/sessions/${sessionId}/runtime`, {
-          cache: 'no-store',
-          credentials: 'same-origin',
-        });
+        const payload = await fetchSessionRuntime(`/api/sessions/${sessionId}/runtime`);
 
-        if (!response.ok || cancelled) {
+        if (!payload || cancelled) {
           return;
         }
-
-        const payload = (await response.json()) as RuntimePayload;
         const statusChanged = payload.sessionStatus !== expectedStatus;
         const questionChanged = payload.questionId !== expectedQuestionId;
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,16 +1,17 @@
+import { cache } from 'react';
 import { redirect } from 'next/navigation';
 
 import type { AppLocale } from '@/i18n/routing';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
-export async function getCurrentUser() {
+export const getCurrentUser = cache(async () => {
   const supabase = createSupabaseServerClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
   return user;
-}
+});
 
 export async function requireUser(locale: AppLocale) {
   const user = await getCurrentUser();

--- a/lib/billing/gating.ts
+++ b/lib/billing/gating.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import { redirect } from 'next/navigation';
 import { getTranslations } from 'next-intl/server';
 
@@ -8,7 +9,7 @@ import { withFeedback } from '@/lib/utils';
 
 export type UserTierCapability = keyof ReturnType<typeof getUserTierCapabilities>;
 
-export async function getUserAccessState(userId: string) {
+export const getUserAccessState = cache(async (userId: string) => {
   const [gatingEnabled, snapshot] = await Promise.all([
     isFeatureEnabled('canEnforceUserTierGating'),
     getUserBillingSnapshot(userId),
@@ -20,7 +21,7 @@ export async function getUserAccessState(userId: string) {
     snapshot,
     capabilities,
   };
-}
+});
 
 export function hasUserTierCapability(
   accessState: Awaited<ReturnType<typeof getUserAccessState>>,

--- a/lib/demo/data.ts
+++ b/lib/demo/data.ts
@@ -41,11 +41,6 @@ type GroupWeeklySchedule = {
 type DashboardGroup = {
   id: string;
   name: string;
-  invite_code: string;
-  created_by: string | null;
-  created_at: string;
-  meeting_link: string | null;
-  max_members: number;
   is_founder: boolean;
   memberCount: number;
   nextSession: DashboardSession | null;
@@ -175,6 +170,26 @@ type GroupMemberStatsRow = {
   group_id: string | null;
   member_count: number | null;
   founder_user_id: string | null;
+};
+
+type DashboardUserGroupRow = {
+  group_id: string | null;
+  is_founder: boolean | null;
+  name: string | null;
+  member_count: number | null;
+};
+
+type DashboardUserSessionRow = {
+  id: string | null;
+  group_id: string | null;
+  name: string | null;
+  scheduled_at: string | null;
+  share_code: string | null;
+  status: DashboardSession['status'] | null;
+  timer_mode: DashboardSession['timer_mode'] | null;
+  timer_seconds: number | null;
+  leader_id: string | null;
+  question_goal: number | null;
 };
 
 const TRIAL_WARNING_THRESHOLD = 85;
@@ -474,14 +489,47 @@ async function getUserSchedule(userId: string) {
 
 async function getDashboardCore(userId: string) {
   const supabase = createSupabaseServerClient();
-  const { data: memberships } = await supabase
+  const dashboardViewsClient = supabase as unknown as {
+    schema: (schemaName: string) => {
+      from: (relation: string) => {
+        select: (columns: string) => {
+          eq: (column: string, value: string) => {
+            order?: (
+              orderColumn: string,
+              options: { ascending: boolean },
+            ) => Promise<{ data: DashboardUserSessionRow[] | null }>;
+          };
+        };
+      };
+    };
+  };
+
+  const userGroupsPromise = (dashboardViewsClient
     .schema('public')
-    .from('group_members')
-    .select('group_id, is_founder')
+    .from('dashboard_user_groups')
+    .select('group_id, is_founder, name, member_count') as {
+      eq: (column: string, value: string) => Promise<{ data: DashboardUserGroupRow[] | null }>;
+    })
     .eq('user_id', userId);
 
-  const groupIds = (memberships ?? []).map((membership) => membership.group_id);
-  if (groupIds.length === 0) {
+  const dashboardUserSessionsRelation = dashboardViewsClient
+    .schema('public')
+    .from('dashboard_user_sessions')
+    .select('id, group_id, name, scheduled_at, share_code, status, timer_mode, timer_seconds, leader_id, question_goal') as {
+    eq: (
+      column: string,
+      value: string,
+    ) => { order: (orderColumn: string, options: { ascending: boolean }) => Promise<{ data: DashboardUserSessionRow[] | null }> };
+  };
+
+  const userSessionsPromise = dashboardUserSessionsRelation
+    .eq('user_id', userId)
+    .order('scheduled_at', { ascending: true })
+    .then((result) => result.data ?? []);
+
+  const [userGroups, userSessions] = await Promise.all([userGroupsPromise, userSessionsPromise]);
+
+  if ((userGroups.data ?? []).length === 0) {
     return {
       groups: [] as DashboardGroup[],
       groupsById: new Map<string, { name: string }>(),
@@ -490,69 +538,69 @@ async function getDashboardCore(userId: string) {
     };
   }
 
-  const memberStatsPromise = (supabase as unknown as {
-    schema: (schemaName: string) => {
-      from: (relation: string) => {
-        select: (columns: string) => {
-          in: (column: string, values: string[]) => Promise<{
-            data: GroupMemberStatsRow[] | null;
-          }>;
-        };
-      };
-    };
-  })
-    .schema('public')
-    .from('group_member_stats')
-    .select('group_id, member_count')
-    .in('group_id', groupIds);
+  const groupsById = new Map<string, { name: string }>();
+  const groups: DashboardGroup[] = [];
 
-  const [groups, memberStatsRows, sessions] = await Promise.all([
-    supabase
-      .schema('public')
-      .from('groups')
-      .select('id, name, invite_code, created_by, created_at, meeting_link, max_members')
-      .in('id', groupIds)
-      .then((result) => result.data ?? []),
-    memberStatsPromise.then((result) => result.data ?? []),
-    supabase
-      .schema('public')
-      .from('sessions')
-      .select('id, group_id, name, scheduled_at, share_code, status, timer_mode, timer_seconds, leader_id, question_goal')
-      .in('group_id', groupIds)
-      .order('scheduled_at', { ascending: true })
-      .then((result) => (result.data ?? []) as DashboardSession[]),
-  ]);
-
-  const groupsById = new Map(groups.map((group) => [group.id, group]));
-  const countsByGroup = new Map<string, number>();
-  for (const item of memberStatsRows) {
-    if (!item.group_id) {
+  for (const row of userGroups.data ?? []) {
+    if (!row.group_id || !row.name) {
       continue;
     }
 
-    countsByGroup.set(item.group_id, item.member_count ?? 0);
+    groupsById.set(row.group_id, { name: row.name });
+    groups.push({
+      id: row.group_id,
+      name: row.name,
+      is_founder: Boolean(row.is_founder),
+      memberCount: row.member_count ?? 0,
+      nextSession: null,
+    });
+  }
+
+  const sessions: DashboardSession[] = [];
+  for (const row of userSessions) {
+    if (
+      !row.id ||
+      !row.group_id ||
+      !row.scheduled_at ||
+      !row.share_code ||
+      !row.status ||
+      !row.timer_mode ||
+      typeof row.timer_seconds !== 'number' ||
+      typeof row.question_goal !== 'number'
+    ) {
+      continue;
+    }
+
+    if (row.status === 'cancelled') {
+      continue;
+    }
+
+    sessions.push({
+      id: row.id,
+      group_id: row.group_id,
+      name: row.name,
+      scheduled_at: row.scheduled_at,
+      share_code: row.share_code,
+      status: row.status,
+      timer_mode: row.timer_mode,
+      timer_seconds: row.timer_seconds,
+      leader_id: row.leader_id,
+      question_goal: row.question_goal,
+    });
   }
 
   const upcomingByGroup = new Map(
     sessions
-      .filter((session) => session.status !== 'completed' && session.status !== 'cancelled')
+      .filter((session) => session.status !== 'completed')
       .map((session) => [session.group_id, session]),
   );
 
+  for (const group of groups) {
+    group.nextSession = upcomingByGroup.get(group.id) ?? null;
+  }
+
   return {
-    groups: (memberships ?? []).reduce<DashboardGroup[]>((acc, membership) => {
-      const group = groupsById.get(membership.group_id);
-      if (!group) return acc;
-
-      acc.push({
-        ...group,
-        is_founder: membership.is_founder,
-        memberCount: countsByGroup.get(group.id) ?? 0,
-        nextSession: upcomingByGroup.get(group.id) ?? null,
-      });
-
-      return acc;
-    }, []),
+    groups,
     groupsById,
     sessions,
     activeSessions: sessions.filter((session) => session.status === 'active'),
@@ -561,22 +609,21 @@ async function getDashboardCore(userId: string) {
 
 async function getCompletedSessionsCount(userId: string) {
   const supabase = createSupabaseServerClient();
-  const { data: memberships } = await supabase
+  const { count } = await (supabase as unknown as {
+    schema: (schemaName: string) => {
+      from: (relation: string) => {
+        select: (columns: string, options: { count: 'exact'; head: true }) => {
+          eq: (column: string, value: string) => {
+            eq: (statusColumn: string, statusValue: string) => Promise<{ count: number | null }>;
+          };
+        };
+      };
+    };
+  })
     .schema('public')
-    .from('group_members')
-    .select('group_id')
-    .eq('user_id', userId);
-
-  const groupIds = (memberships ?? []).map((membership) => membership.group_id);
-  if (groupIds.length === 0) {
-    return 0;
-  }
-
-  const { count } = await supabase
-    .schema('public')
-    .from('sessions')
+    .from('dashboard_user_sessions')
     .select('*', { count: 'exact', head: true })
-    .in('group_id', groupIds)
+    .eq('user_id', userId)
     .eq('status', 'completed');
 
   return count ?? 0;
@@ -633,8 +680,8 @@ export const getDashboardSessionsData = cache(async (user: User, activeGroupId?:
     questionCount: questionCountBySession.get(session.id) ?? 0,
   }));
 
-  const dedupedSessions = dedupeDashboardSessions(enrichedSessions.filter((session) => session.status !== 'cancelled'));
-  const nextSession = enrichedSessions.find((session) => session.status !== 'completed' && session.status !== 'cancelled') ?? null;
+  const dedupedSessions = dedupeDashboardSessions(enrichedSessions);
+  const nextSession = enrichedSessions.find((session) => session.status !== 'completed') ?? null;
 
   perf.done({
     groups: core.groups.length,

--- a/lib/demo/data.ts
+++ b/lib/demo/data.ts
@@ -587,97 +587,16 @@ async function getDashboardSessionCounts(userId: string, sessionIds: string[]) {
   };
 }
 
-async function getPrimaryGroupDashboard(primaryGroup: DashboardGroup | null, sessions: DashboardSession[]) {
-  if (!primaryGroup) {
-    return {
-      group: null,
-      schedules: [],
-      weeklyProgressPercentage: 0,
-      weeklyCompletedQuestions: 0,
-      weeklyTargetQuestions: 0,
-      memberPerformance: [],
-    } satisfies GroupDashboardData;
-  }
-
-  const supabase = createSupabaseServerClient();
-  const primaryGroupSessions = sessions.filter((session) => session.group_id === primaryGroup.id);
-  const currentWeekStart = new Date();
-  const currentDay = currentWeekStart.getDay();
-  const offsetToMonday = currentDay === 0 ? 6 : currentDay - 1;
-  currentWeekStart.setDate(currentWeekStart.getDate() - offsetToMonday);
-  currentWeekStart.setHours(0, 0, 0, 0);
-
-  const weeklySessions = primaryGroupSessions.filter((session) => {
-    if (session.status === 'cancelled') return false;
-    return new Date(session.scheduled_at).getTime() >= currentWeekStart.getTime();
-  });
-
-  const weeklySessionIds = weeklySessions.map((session) => session.id);
-  const [{ data: schedules }, { data: weeklyQuestions }] = await Promise.all([
-    supabase
-      .schema('public')
-      .from('group_weekly_schedules')
-      .select('id, weekday, start_time, end_time, question_goal')
-      .eq('group_id', primaryGroup.id)
-      .order('weekday', { ascending: true })
-      .order('start_time', { ascending: true }),
-    weeklySessionIds.length > 0
-      ? supabase.schema('public').from('questions').select('id, session_id').in('session_id', weeklySessionIds)
-      : Promise.resolve({ data: [] as { id: string; session_id: string }[] }),
-  ]);
-
-  const safeWeeklyQuestions = weeklyQuestions ?? [];
-  const weeklyQuestionIds = safeWeeklyQuestions.map((question) => question.id);
-  const { data: weeklyAnswers } =
-    weeklyQuestionIds.length > 0
-      ? await supabase
-          .schema('public')
-          .from('answers')
-          .select('question_id')
-          .in('question_id', weeklyQuestionIds)
-      : { data: [] as { question_id: string }[] };
-
-  const weeklyTargetQuestions = (schedules ?? []).reduce((sum, schedule) => sum + schedule.question_goal, 0);
-  const qualifyingGroupSize = primaryGroup.memberCount >= 2 && primaryGroup.memberCount <= 5;
-  const questionAnswerCounts = new Map<string, number>();
-  for (const answer of weeklyAnswers ?? []) {
-    questionAnswerCounts.set(answer.question_id, (questionAnswerCounts.get(answer.question_id) ?? 0) + 1);
-  }
-
-  const weeklyCompletedQuestions = qualifyingGroupSize
-    ? safeWeeklyQuestions.filter((question) => (questionAnswerCounts.get(question.id) ?? 0) >= primaryGroup.memberCount).length
-    : 0;
-
-  return {
-    group: primaryGroup,
-    schedules: sortWeeklySchedules(schedules ?? []),
-    weeklyProgressPercentage:
-      weeklyTargetQuestions > 0 ? Math.min(100, Math.round((weeklyCompletedQuestions / weeklyTargetQuestions) * 100)) : 0,
-    weeklyCompletedQuestions,
-    weeklyTargetQuestions,
-    memberPerformance: [],
-  } satisfies GroupDashboardData;
-}
-
 export const getDashboardSessionsData = cache(async (user: User, activeGroupId?: string | null) => {
   const perf = createPerfTracker(`getDashboardSessionsData:${user.id}`);
   const core = await getDashboardCore(user.id);
   perf.step('dashboard_core_loaded');
 
   const sessionIds = core.sessions.map((session) => session.id);
-  const primaryGroup =
-    (activeGroupId ? core.groups.find((group) => group.id === activeGroupId) : null) ??
-    core.groups.find((group) => group.is_founder) ??
-    core.groups[0] ??
-    null;
-
-  const [sessionCounts, groupDashboard] = await Promise.all([
-    getDashboardSessionCounts(user.id, sessionIds),
-    getPrimaryGroupDashboard(primaryGroup, core.sessions),
-  ]);
+  void activeGroupId;
+  const sessionCounts = await getDashboardSessionCounts(user.id, sessionIds);
   const { questionCountBySession, answeredQuestionCountBySession } = sessionCounts;
   perf.step('session_rollups_loaded');
-  perf.step('group_dashboard_loaded');
 
   const enrichedSessions = core.sessions.map((session) => ({
     ...session,
@@ -699,7 +618,14 @@ export const getDashboardSessionsData = cache(async (user: User, activeGroupId?:
     sessions: dedupedSessions,
     activeSessions: core.activeSessions,
     nextSession,
-    groupDashboard,
+    groupDashboard: {
+      group: null,
+      schedules: [],
+      weeklyProgressPercentage: 0,
+      weeklyCompletedQuestions: 0,
+      weeklyTargetQuestions: 0,
+      memberPerformance: [],
+    } satisfies GroupDashboardData,
   };
 });
 
@@ -959,51 +885,6 @@ export const getGroupCoreData = cache(async (groupId: string, user: User) => {
   const safeMembers = members ?? [];
   const safeSessions = sessions ?? [];
   const safeWeeklySchedules = sortWeeklySchedules(weeklySchedules ?? []);
-  const sessionIds = safeSessions.map((session) => session.id);
-  const currentWeekStart = new Date();
-  const currentDay = currentWeekStart.getDay();
-  const offsetToMonday = currentDay === 0 ? 6 : currentDay - 1;
-  currentWeekStart.setDate(currentWeekStart.getDate() - offsetToMonday);
-  currentWeekStart.setHours(0, 0, 0, 0);
-
-  const weeklySessions = safeSessions.filter((session) => {
-    if (session.status === 'cancelled') return false;
-    return new Date(session.scheduled_at).getTime() >= currentWeekStart.getTime();
-  });
-  const weeklySessionIds = new Set(weeklySessions.map((session) => session.id));
-
-  const { data: groupQuestions } =
-    sessionIds.length > 0
-      ? await supabase.schema('public').from('questions').select('id, session_id').in('session_id', sessionIds)
-      : { data: [] as { id: string; session_id: string }[] };
-  const weeklyQuestionIds = new Set(
-    (groupQuestions ?? [])
-      .filter((question) => weeklySessionIds.has(question.session_id))
-      .map((question) => question.id),
-  );
-
-  const { data: weeklyAnswers } =
-    weeklyQuestionIds.size > 0
-      ? await supabase
-          .schema('public')
-          .from('answers')
-          .select('question_id')
-          .in('question_id', [...weeklyQuestionIds])
-      : { data: [] as { question_id: string }[] };
-
-  const questionAnswerCounts = new Map<string, number>();
-  for (const answer of weeklyAnswers ?? []) {
-    questionAnswerCounts.set(answer.question_id, (questionAnswerCounts.get(answer.question_id) ?? 0) + 1);
-  }
-
-  const weeklyTargetQuestions = safeWeeklySchedules.reduce((sum, schedule) => sum + schedule.question_goal, 0);
-  const qualifyingGroupSize = safeMembers.length >= 2 && safeMembers.length <= 5;
-  const weeklyCompletedQuestions = qualifyingGroupSize
-    ? (groupQuestions ?? []).filter(
-        (question) => weeklyQuestionIds.has(question.id) && (questionAnswerCounts.get(question.id) ?? 0) >= safeMembers.length,
-      ).length
-    : 0;
-
   const founderCaptainId = safeMembers.find((member) => member.is_founder)?.user_id ?? null;
   const sessionLeaderId =
     safeSessions.find((session) => session.status === 'active')?.leader_id ??
@@ -1027,10 +908,6 @@ export const getGroupCoreData = cache(async (groupId: string, user: User) => {
     membership,
     sessions: safeSessions,
     weeklySchedules: safeWeeklySchedules,
-    weeklyCompletedQuestions,
-    weeklyTargetQuestions,
-    weeklyProgressPercentage:
-      weeklyTargetQuestions > 0 ? Math.min(100, Math.round((weeklyCompletedQuestions / weeklyTargetQuestions) * 100)) : 0,
     currentCaptainId: founderCaptainId ?? sessionLeaderId ?? null,
   };
 });

--- a/lib/demo/data.ts
+++ b/lib/demo/data.ts
@@ -190,6 +190,8 @@ type DashboardUserSessionRow = {
   timer_seconds: number | null;
   leader_id: string | null;
   question_goal: number | null;
+  question_count: number | null;
+  answered_question_count: number | null;
 };
 
 const TRIAL_WARNING_THRESHOLD = 85;
@@ -515,7 +517,9 @@ async function getDashboardCore(userId: string) {
   const dashboardUserSessionsRelation = dashboardViewsClient
     .schema('public')
     .from('dashboard_user_sessions')
-    .select('id, group_id, name, scheduled_at, share_code, status, timer_mode, timer_seconds, leader_id, question_goal') as {
+    .select(
+      'id, group_id, name, scheduled_at, share_code, status, timer_mode, timer_seconds, leader_id, question_goal, question_count, answered_question_count',
+    ) as {
     eq: (
       column: string,
       value: string,
@@ -586,6 +590,8 @@ async function getDashboardCore(userId: string) {
       timer_seconds: row.timer_seconds,
       leader_id: row.leader_id,
       question_goal: row.question_goal,
+      questionCount: row.question_count ?? 0,
+      answeredQuestionCount: row.answered_question_count ?? 0,
     });
   }
 
@@ -629,55 +635,17 @@ async function getCompletedSessionsCount(userId: string) {
   return count ?? 0;
 }
 
-async function getDashboardSessionCounts(userId: string, sessionIds: string[]) {
-  if (sessionIds.length === 0) {
-    return {
-      questionCountBySession: new Map<string, number>(),
-      answeredQuestionCountBySession: new Map<string, number>(),
-    };
-  }
-
-  const supabase = createSupabaseServerClient();
-  const [{ data: questionCounts }, { data: answeredCounts }] = await Promise.all([
-    supabase
-      .schema('public')
-      .from('dashboard_session_question_counts')
-      .select('session_id, question_count')
-      .in('session_id', sessionIds),
-    supabase
-      .schema('public')
-      .from('dashboard_user_session_answer_counts')
-      .select('session_id, answered_question_count')
-      .eq('user_id', userId)
-      .in('session_id', sessionIds),
-  ]);
-
-  return {
-    questionCountBySession: new Map(
-      (questionCounts ?? []).flatMap((row) => (row.session_id ? [[row.session_id, row.question_count]] : [])),
-    ),
-    answeredQuestionCountBySession: new Map(
-      (answeredCounts ?? []).flatMap((row) => (row.session_id ? [[row.session_id, row.answered_question_count]] : [])),
-    ),
-  };
-}
-
 export const getDashboardSessionsData = cache(async (user: User, activeGroupId?: string | null) => {
   const perf = createPerfTracker(`getDashboardSessionsData:${user.id}`);
   const core = await getDashboardCore(user.id);
   perf.step('dashboard_core_loaded');
 
-  const sessionIds = core.sessions.map((session) => session.id);
   void activeGroupId;
-  const sessionCounts = await getDashboardSessionCounts(user.id, sessionIds);
-  const { questionCountBySession, answeredQuestionCountBySession } = sessionCounts;
   perf.step('session_rollups_loaded');
 
   const enrichedSessions = core.sessions.map((session) => ({
     ...session,
     groupName: core.groupsById.get(session.group_id)?.name ?? null,
-    answeredQuestionCount: answeredQuestionCountBySession.get(session.id) ?? 0,
-    questionCount: questionCountBySession.get(session.id) ?? 0,
   }));
 
   const dedupedSessions = dedupeDashboardSessions(enrichedSessions);

--- a/lib/demo/data.ts
+++ b/lib/demo/data.ts
@@ -636,7 +636,14 @@ async function getCompletedSessionsCount(userId: string) {
 }
 
 export const getDashboardSessionsData = cache(async (user: User, activeGroupId?: string | null) => {
-  const perf = createPerfTracker(`getDashboardSessionsData:${user.id}`);
+  const perf = createPerfTracker(`getDashboardSessionsData:${user.id}`, {
+    userId: user.id,
+    minDurationMs: 250,
+    metadata: {
+      trace_group: 'dashboard',
+      trace_kind: 'sessions',
+    },
+  });
   const core = await getDashboardCore(user.id);
   perf.step('dashboard_core_loaded');
 
@@ -673,7 +680,14 @@ export const getDashboardSessionsData = cache(async (user: User, activeGroupId?:
 });
 
 export const getDashboardPerformanceData = cache(async (userId: string) => {
-  const perf = createPerfTracker(`getDashboardPerformanceData:${userId}`);
+  const perf = createPerfTracker(`getDashboardPerformanceData:${userId}`, {
+    userId,
+    minDurationMs: 250,
+    metadata: {
+      trace_group: 'dashboard',
+      trace_kind: 'performance',
+    },
+  });
   const supabase = createSupabaseServerClient();
   const completedSessionsCountPromise = getCompletedSessionsCount(userId);
   const sessionConfidenceBreakdownPromise = (supabase as unknown as {
@@ -825,7 +839,15 @@ export const getDashboardData = cache(
 );
 
 export const getGroupCoreData = cache(async (groupId: string, user: User) => {
-  const perf = createPerfTracker(`getGroupCoreData:${groupId}`);
+  const perf = createPerfTracker(`getGroupCoreData:${groupId}`, {
+    userId: user.id,
+    groupId,
+    minDurationMs: 250,
+    metadata: {
+      trace_group: 'groups',
+      trace_kind: 'group_core',
+    },
+  });
   const supabase = createSupabaseServerClient();
 
   const { data: membership } = await supabase

--- a/lib/demo/data.ts
+++ b/lib/demo/data.ts
@@ -171,6 +171,12 @@ type MaterializedSessionConfidenceBreakdownRow = {
   high_count: number | null;
 };
 
+type GroupMemberStatsRow = {
+  group_id: string | null;
+  member_count: number | null;
+  founder_user_id: string | null;
+};
+
 const TRIAL_WARNING_THRESHOLD = 85;
 
 async function getUsersMap(supabase: PublicClient, userIds: string[]) {
@@ -484,19 +490,30 @@ async function getDashboardCore(userId: string) {
     };
   }
 
-  const [groups, memberCounts, sessions] = await Promise.all([
+  const memberStatsPromise = (supabase as unknown as {
+    schema: (schemaName: string) => {
+      from: (relation: string) => {
+        select: (columns: string) => {
+          in: (column: string, values: string[]) => Promise<{
+            data: GroupMemberStatsRow[] | null;
+          }>;
+        };
+      };
+    };
+  })
+    .schema('public')
+    .from('group_member_stats')
+    .select('group_id, member_count')
+    .in('group_id', groupIds);
+
+  const [groups, memberStatsRows, sessions] = await Promise.all([
     supabase
       .schema('public')
       .from('groups')
       .select('id, name, invite_code, created_by, created_at, meeting_link, max_members')
       .in('id', groupIds)
       .then((result) => result.data ?? []),
-    supabase
-      .schema('public')
-      .from('group_members')
-      .select('group_id')
-      .in('group_id', groupIds)
-      .then((result) => result.data ?? []),
+    memberStatsPromise.then((result) => result.data ?? []),
     supabase
       .schema('public')
       .from('sessions')
@@ -508,8 +525,12 @@ async function getDashboardCore(userId: string) {
 
   const groupsById = new Map(groups.map((group) => [group.id, group]));
   const countsByGroup = new Map<string, number>();
-  for (const item of memberCounts) {
-    countsByGroup.set(item.group_id, (countsByGroup.get(item.group_id) ?? 0) + 1);
+  for (const item of memberStatsRows) {
+    if (!item.group_id) {
+      continue;
+    }
+
+    countsByGroup.set(item.group_id, item.member_count ?? 0);
   }
 
   const upcomingByGroup = new Map(
@@ -804,14 +825,33 @@ export const getGroupCoreData = cache(async (groupId: string, user: User) => {
     return null;
   }
 
-  const [{ data: group }, { data: members }, { data: sessions }, { data: weeklySchedules }] = await Promise.all([
+  const memberStatsPromise = (supabase as unknown as {
+    schema: (schemaName: string) => {
+      from: (relation: string) => {
+        select: (columns: string) => {
+          eq: (column: string, value: string) => {
+            maybeSingle: () => Promise<{
+              data: GroupMemberStatsRow | null;
+            }>;
+          };
+        };
+      };
+    };
+  })
+    .schema('public')
+    .from('group_member_stats')
+    .select('group_id, member_count, founder_user_id')
+    .eq('group_id', groupId)
+    .maybeSingle();
+
+  const [{ data: group }, { data: memberStats }, { data: sessions }, { data: weeklySchedules }] = await Promise.all([
     supabase
       .schema('public')
       .from('groups')
       .select('id, name, invite_code, created_by, created_at, meeting_link, max_members')
       .eq('id', groupId)
       .single(),
-    supabase.schema('public').from('group_members').select('user_id, is_founder').eq('group_id', groupId),
+    memberStatsPromise,
     supabase
       .schema('public')
       .from('sessions')
@@ -827,17 +867,17 @@ export const getGroupCoreData = cache(async (groupId: string, user: User) => {
       .order('start_time', { ascending: true }),
   ]);
 
-  const safeMembers = members ?? [];
   const safeSessions = sessions ?? [];
   const safeWeeklySchedules = sortWeeklySchedules(weeklySchedules ?? []);
-  const founderCaptainId = safeMembers.find((member) => member.is_founder)?.user_id ?? null;
+  const memberCount = memberStats?.member_count ?? 0;
+  const founderCaptainId = memberStats?.founder_user_id ?? null;
   const sessionLeaderId =
     safeSessions.find((session) => session.status === 'active')?.leader_id ??
     safeSessions.find((session) => session.status === 'scheduled')?.leader_id ??
     null;
 
   perf.done({
-    members: safeMembers.length,
+    members: memberCount,
     sessions: safeSessions.length,
     weeklySchedules: safeWeeklySchedules.length,
   });
@@ -847,7 +887,7 @@ export const getGroupCoreData = cache(async (groupId: string, user: User) => {
       ? {
           ...group,
           is_founder: membership.is_founder,
-          memberCount: safeMembers.length,
+          memberCount,
         }
       : null,
     membership,

--- a/lib/demo/data.ts
+++ b/lib/demo/data.ts
@@ -162,6 +162,15 @@ type MaterializedProfileAnalyticsRow = {
   weekly_trend: unknown;
 };
 
+type MaterializedSessionConfidenceBreakdownRow = {
+  session_id: string | null;
+  session_name: string | null;
+  scheduled_at: string | null;
+  low_count: number | null;
+  medium_count: number | null;
+  high_count: number | null;
+};
+
 const TRIAL_WARNING_THRESHOLD = 85;
 
 async function getUsersMap(supabase: PublicClient, userIds: string[]) {
@@ -472,7 +481,6 @@ async function getDashboardCore(userId: string) {
       groupsById: new Map<string, { name: string }>(),
       sessions: [] as DashboardSession[],
       activeSessions: [] as DashboardSession[],
-      completedSessionsCount: 0,
     };
   }
 
@@ -527,7 +535,6 @@ async function getDashboardCore(userId: string) {
     groupsById,
     sessions,
     activeSessions: sessions.filter((session) => session.status === 'active'),
-    completedSessionsCount: sessions.filter((session) => session.status === 'completed').length,
   };
 }
 
@@ -544,14 +551,14 @@ async function getCompletedSessionsCount(userId: string) {
     return 0;
   }
 
-  const { data: sessions } = await supabase
+  const { count } = await supabase
     .schema('public')
     .from('sessions')
-    .select('status')
+    .select('*', { count: 'exact', head: true })
     .in('group_id', groupIds)
     .eq('status', 'completed');
 
-  return sessions?.length ?? 0;
+  return count ?? 0;
 }
 
 async function getDashboardSessionCounts(userId: string, sessionIds: string[]) {
@@ -633,105 +640,24 @@ export const getDashboardPerformanceData = cache(async (userId: string) => {
   const perf = createPerfTracker(`getDashboardPerformanceData:${userId}`);
   const supabase = createSupabaseServerClient();
   const completedSessionsCountPromise = getCompletedSessionsCount(userId);
-  const sessionConfidenceBreakdownPromise = (async () => {
-    const { data: answerRows } = await supabase
-      .schema('public')
-      .from('answers')
-      .select('question_id, confidence')
-      .eq('user_id', userId)
-      .not('confidence', 'is', null);
-
-    const safeAnswerRows = (answerRows ?? []).filter(
-      (row): row is { question_id: string; confidence: ConfidenceLevel } =>
-        typeof row.question_id === 'string' &&
-        (row.confidence === 'low' || row.confidence === 'medium' || row.confidence === 'high'),
-    );
-
-    if (safeAnswerRows.length === 0) {
-      return [] as SessionConfidenceBreakdownItem[];
-    }
-
-    const questionIds = [...new Set(safeAnswerRows.map((row) => row.question_id))];
-    const { data: questionRows } = await supabase
-      .schema('public')
-      .from('questions')
-      .select('id, session_id')
-      .in('id', questionIds);
-
-    const questionSessionMap = new Map(
-      (questionRows ?? [])
-        .filter((row): row is { id: string; session_id: string } => typeof row.id === 'string' && typeof row.session_id === 'string')
-        .map((row) => [row.id, row.session_id]),
-    );
-
-    const sessionIds = [...new Set([...questionSessionMap.values()])];
-    if (sessionIds.length === 0) {
-      return [] as SessionConfidenceBreakdownItem[];
-    }
-
-    const { data: sessionRows } = await supabase
-      .schema('public')
-      .from('sessions')
-      .select('id, name, scheduled_at, group_id')
-      .in('id', sessionIds);
-
-    const groupIds = [
-      ...new Set(
-        (sessionRows ?? [])
-          .map((row) => (typeof row.group_id === 'string' ? row.group_id : null))
-          .filter((value): value is string => Boolean(value)),
-      ),
-    ];
-
-    const { data: groupRows } =
-      groupIds.length > 0
-        ? await supabase.schema('public').from('groups').select('id, name').in('id', groupIds)
-        : { data: [] as { id: string; name: string }[] };
-
-    const sessionMetaMap = new Map(
-      (sessionRows ?? [])
-        .filter(
-          (row): row is { id: string; name: string | null; scheduled_at: string; group_id: string } =>
-            typeof row.id === 'string' && typeof row.scheduled_at === 'string',
-        )
-        .map((row) => [row.id, row]),
-    );
-    const groupNameMap = new Map(
-      (groupRows ?? [])
-        .filter((row): row is { id: string; name: string } => typeof row.id === 'string' && typeof row.name === 'string')
-        .map((row) => [row.id, row.name]),
-    );
-
-    const breakdownMap = new Map<string, SessionConfidenceBreakdownItem>();
-    for (const answer of safeAnswerRows) {
-      const sessionId = questionSessionMap.get(answer.question_id);
-      if (!sessionId) continue;
-
-      const sessionMeta = sessionMetaMap.get(sessionId);
-      if (!sessionMeta) continue;
-
-      const existing =
-        breakdownMap.get(sessionId) ??
-        {
-          sessionId,
-          sessionName: sessionMeta.name?.trim() || (sessionMeta.group_id ? groupNameMap.get(sessionMeta.group_id) ?? 'Session' : 'Session'),
-          scheduledAt: sessionMeta.scheduled_at,
-          low: 0,
-          medium: 0,
-          high: 0,
+  const sessionConfidenceBreakdownPromise = (supabase as unknown as {
+    schema: (schemaName: string) => {
+      from: (relation: string) => {
+        select: (columns: string) => {
+          eq: (column: string, value: string) => {
+            order: (column: string, options: { ascending: boolean }) => Promise<{
+              data: MaterializedSessionConfidenceBreakdownRow[] | null;
+            }>;
+          };
         };
-
-      if (answer.confidence === 'low') existing.low += 1;
-      if (answer.confidence === 'medium') existing.medium += 1;
-      if (answer.confidence === 'high') existing.high += 1;
-
-      breakdownMap.set(sessionId, existing);
-    }
-
-    return Array.from(breakdownMap.values()).sort(
-      (left, right) => new Date(right.scheduledAt).getTime() - new Date(left.scheduledAt).getTime(),
-    );
-  })();
+      };
+    };
+  })
+    .schema('public')
+    .from('dashboard_user_session_confidence_breakdown')
+    .select('session_id, session_name, scheduled_at, low_count, medium_count, high_count')
+    .eq('user_id', userId)
+    .order('scheduled_at', { ascending: false });
   const metricsPromise = supabase
     .schema('public')
     .from('dashboard_user_answer_metrics')
@@ -755,7 +681,7 @@ export const getDashboardPerformanceData = cache(async (userId: string) => {
     .eq('user_id', userId)
     .maybeSingle();
 
-  const [completedSessionsCount, sessionConfidenceBreakdown, metricsResult, profileAnalyticsResult] = await Promise.all([
+  const [completedSessionsCount, sessionConfidenceBreakdownResult, metricsResult, profileAnalyticsResult] = await Promise.all([
     completedSessionsCountPromise,
     sessionConfidenceBreakdownPromise,
     metricsPromise,
@@ -769,6 +695,25 @@ export const getDashboardPerformanceData = cache(async (userId: string) => {
   const answeredCount = metricsRow?.answered_count ?? 0;
   const correctCount = metricsRow?.correct_count ?? 0;
   const incorrectCount = metricsRow?.incorrect_count ?? 0;
+  const sessionConfidenceBreakdown: SessionConfidenceBreakdownItem[] = [];
+  for (const row of sessionConfidenceBreakdownResult.data ?? []) {
+    if (
+      typeof row.session_id !== 'string' ||
+      typeof row.session_name !== 'string' ||
+      typeof row.scheduled_at !== 'string'
+    ) {
+      continue;
+    }
+
+    sessionConfidenceBreakdown.push({
+      sessionId: row.session_id,
+      sessionName: row.session_name,
+      scheduledAt: row.scheduled_at,
+      low: row.low_count ?? 0,
+      medium: row.medium_count ?? 0,
+      high: row.high_count ?? 0,
+    });
+  }
   const averageConfidence =
     answeredCount > 0 && metricsRow?.average_confidence_score
       ? scoreToConfidenceLevel(metricsRow.average_confidence_score)

--- a/lib/features/flags.ts
+++ b/lib/features/flags.ts
@@ -4,6 +4,7 @@ import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 export const FEATURE_FLAGS = {
   canUseUbiquitousLogging: false,
+  canUsePerformanceLogging: true,
   canUseStripeBilling: false,
   canEnforceUserTierGating: true,
 } as const;

--- a/lib/groups/server.ts
+++ b/lib/groups/server.ts
@@ -165,6 +165,82 @@ export async function getGroupMemberPerformance(groupId: string, fallbackEmail =
   });
 }
 
+export async function getGroupWeeklyProgress(groupId: string) {
+  const supabase = createSupabaseServerClient();
+  const [{ data: members }, { data: sessions }, { data: schedules }] = await Promise.all([
+    supabase.schema('public').from('group_members').select('user_id').eq('group_id', groupId),
+    supabase
+      .schema('public')
+      .from('sessions')
+      .select('id, scheduled_at, status')
+      .eq('group_id', groupId),
+    supabase
+      .schema('public')
+      .from('group_weekly_schedules')
+      .select('question_goal')
+      .eq('group_id', groupId),
+  ]);
+
+  const safeMembers = members ?? [];
+  const safeSessions = sessions ?? [];
+  const weeklyTargetQuestions = (schedules ?? []).reduce((sum, schedule) => sum + (schedule.question_goal ?? 0), 0);
+  const qualifyingGroupSize = safeMembers.length >= 2 && safeMembers.length <= 5;
+
+  if (!qualifyingGroupSize || safeSessions.length === 0) {
+    return {
+      weeklyCompletedQuestions: 0,
+      weeklyTargetQuestions,
+    };
+  }
+
+  const currentWeekStart = new Date();
+  const currentDay = currentWeekStart.getDay();
+  const offsetToMonday = currentDay === 0 ? 6 : currentDay - 1;
+  currentWeekStart.setDate(currentWeekStart.getDate() - offsetToMonday);
+  currentWeekStart.setHours(0, 0, 0, 0);
+
+  const weeklySessionIds = safeSessions
+    .filter((session) => session.status !== 'cancelled' && new Date(session.scheduled_at).getTime() >= currentWeekStart.getTime())
+    .map((session) => session.id);
+
+  if (weeklySessionIds.length === 0) {
+    return {
+      weeklyCompletedQuestions: 0,
+      weeklyTargetQuestions,
+    };
+  }
+
+  const { data: questions } = await supabase
+    .schema('public')
+    .from('questions')
+    .select('id')
+    .in('session_id', weeklySessionIds);
+
+  const questionIds = (questions ?? []).map((question) => question.id);
+  if (questionIds.length === 0) {
+    return {
+      weeklyCompletedQuestions: 0,
+      weeklyTargetQuestions,
+    };
+  }
+
+  const { data: answers } = await supabase
+    .schema('public')
+    .from('answers')
+    .select('question_id')
+    .in('question_id', questionIds);
+
+  const questionAnswerCounts = new Map<string, number>();
+  for (const answer of answers ?? []) {
+    questionAnswerCounts.set(answer.question_id, (questionAnswerCounts.get(answer.question_id) ?? 0) + 1);
+  }
+
+  return {
+    weeklyCompletedQuestions: questionIds.filter((questionId) => (questionAnswerCounts.get(questionId) ?? 0) >= safeMembers.length).length,
+    weeklyTargetQuestions,
+  };
+}
+
 export async function getLiveGroupsForUser(userId: string, locale: string) {
   const supabase = createSupabaseServerClient();
   const supabaseAdmin = createSupabaseAdminClient();

--- a/lib/logging/events.ts
+++ b/lib/logging/events.ts
@@ -38,6 +38,7 @@ export const APP_EVENTS = {
   pwaInstallPromptShown: 'pwa_install_prompt_shown',
   pwaInstallAccepted: 'pwa_install_accepted',
   pwaLaunchedFromHomeScreen: 'pwa_launched_from_home_screen',
+  performanceTraceRecorded: 'performance_trace_recorded',
   stripeWebhookReceived: 'stripe_webhook_received',
   stripeWebhookSynced: 'stripe_webhook_synced',
   stripeWebhookIgnored: 'stripe_webhook_ignored',

--- a/lib/observability/perf.ts
+++ b/lib/observability/perf.ts
@@ -1,11 +1,50 @@
+import 'server-only';
+
+import type { AppLocale } from '@/i18n/routing';
+import { APP_EVENTS } from '@/lib/logging/events';
+import { logAppEvent } from '@/lib/logging/logger';
+import type { Json } from '@/lib/supabase/types';
+
 const PERF_ENABLED = process.env.NODE_ENV !== 'production';
 
-export function createPerfTracker(label: string) {
+type PerfLogContext = {
+  userId?: string | null;
+  groupId?: string | null;
+  sessionId?: string | null;
+  locale?: AppLocale | null;
+  sampleRate?: number;
+  minDurationMs?: number;
+  metadata?: Record<string, Json | undefined>;
+};
+
+export function createPerfTracker(label: string, initialContext?: PerfLogContext) {
   const startedAt = Date.now();
   const steps: Array<{ label: string; elapsedMs: number; durationMs: number }> = [];
   let lastStepAt = startedAt;
+  let logContext = initialContext ?? null;
+
+  function shouldPersist(elapsedMs: number) {
+    if (!logContext) return false;
+    const minDurationMs = logContext.minDurationMs ?? 0;
+    if (elapsedMs < minDurationMs) {
+      return false;
+    }
+
+    const sampleRate = logContext.sampleRate ?? 1;
+    if (sampleRate <= 0) {
+      return false;
+    }
+
+    return sampleRate >= 1 || Math.random() <= sampleRate;
+  }
 
   return {
+    setContext(nextContext: PerfLogContext) {
+      logContext = {
+        ...(logContext ?? {}),
+        ...nextContext,
+      };
+    },
     step(stepLabel: string) {
       if (!PERF_ENABLED) return;
       const now = Date.now();
@@ -27,11 +66,33 @@ export function createPerfTracker(label: string) {
       };
     },
     done(metadata?: Record<string, unknown>) {
-      if (!PERF_ENABLED) return;
       const elapsed = Date.now() - startedAt;
-      console.info(`[perf] ${label}:done ${elapsed}ms`, {
-        ...(metadata ?? {}),
-        steps,
+      if (PERF_ENABLED) {
+        console.info(`[perf] ${label}:done ${elapsed}ms`, {
+          ...(metadata ?? {}),
+          steps,
+        });
+      }
+
+      if (!shouldPersist(elapsed)) {
+        return;
+      }
+
+      void logAppEvent({
+        eventName: APP_EVENTS.performanceTraceRecorded,
+        flagKey: 'canUsePerformanceLogging',
+        useAdmin: true,
+        locale: logContext?.locale ?? null,
+        userId: logContext?.userId ?? null,
+        groupId: logContext?.groupId ?? null,
+        sessionId: logContext?.sessionId ?? null,
+        metadata: {
+          trace_name: label,
+          total_ms: elapsed,
+          steps,
+          ...(logContext?.metadata ?? {}),
+          ...(metadata ?? {}),
+        },
       });
     },
   };

--- a/lib/session/flow.ts
+++ b/lib/session/flow.ts
@@ -1,0 +1,204 @@
+import 'server-only';
+
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { ANSWER_OPTIONS } from '@/lib/types/demo';
+
+import type { AppLocale } from '@/i18n/routing';
+
+export type SessionRuntimeAccessRow = {
+  session_id: string | null;
+  group_id: string | null;
+  status: string | null;
+  leader_id: string | null;
+  timer_mode: 'per_question' | 'global' | null;
+  timer_seconds: number | null;
+  question_goal: number | null;
+  started_at: string | null;
+  is_founder: boolean | null;
+  member_count: number | null;
+};
+
+export type SessionAccessSnapshot = {
+  id: string;
+  group_id: string;
+  status: string;
+  leader_id: string | null;
+  timer_mode: 'per_question' | 'global';
+  timer_seconds: number;
+  question_goal: number;
+  started_at: string | null;
+};
+
+export function getGlobalDeadline(startedAt: string | null, timerSeconds: number) {
+  const startedAtMs = startedAt ? new Date(startedAt).getTime() : Date.now();
+  return new Date(startedAtMs + timerSeconds * 1000);
+}
+
+export function isCustomAnswerLetter(value: string) {
+  return /^[A-Z]$/.test(value);
+}
+
+export async function getCurrentAuthUser() {
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return { supabase, user };
+}
+
+export async function loadSessionRuntimeAccess(
+  supabase: ReturnType<typeof createSupabaseServerClient>,
+  sessionId: string,
+  userId: string,
+) {
+  const { data: access } = await (supabase as unknown as {
+    schema: (schemaName: string) => {
+      from: (relation: string) => {
+        select: (columns: string) => {
+          eq: (column: string, value: string) => {
+            eq: (column: string, value: string) => {
+              maybeSingle: () => Promise<{ data: SessionRuntimeAccessRow | null }>;
+            };
+          };
+        };
+      };
+    };
+  })
+    .schema('public')
+    .from('session_runtime_access')
+    .select(
+      'session_id, group_id, status, leader_id, timer_mode, timer_seconds, question_goal, started_at, is_founder, member_count',
+    )
+    .eq('session_id', sessionId)
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  return access;
+}
+
+export function getSessionAccessSnapshot(access: SessionRuntimeAccessRow | null): SessionAccessSnapshot | null {
+  if (
+    !access?.session_id ||
+    !access.group_id ||
+    !access.status ||
+    !access.timer_mode ||
+    typeof access.timer_seconds !== 'number' ||
+    typeof access.question_goal !== 'number'
+  ) {
+    return null;
+  }
+
+  return {
+    id: access.session_id,
+    group_id: access.group_id,
+    status: access.status,
+    leader_id: access.leader_id,
+    timer_mode: access.timer_mode,
+    timer_seconds: access.timer_seconds,
+    question_goal: access.question_goal,
+    started_at: access.started_at,
+  };
+}
+
+export async function ensureQuestion(
+  supabase: ReturnType<typeof createSupabaseServerClient>,
+  sessionId: string,
+  orderIndex: number,
+  userId: string,
+  session: Pick<SessionAccessSnapshot, 'timer_mode' | 'timer_seconds' | 'started_at'>,
+) {
+  const now = new Date();
+  const answerDeadlineAt =
+    session.timer_mode === 'global'
+      ? getGlobalDeadline(session.started_at ?? now.toISOString(), session.timer_seconds)
+      : new Date(now.getTime() + session.timer_seconds * 1000);
+
+  const { data: existing } = await supabase
+    .schema('public')
+    .from('questions')
+    .select('id, answer_deadline_at')
+    .eq('session_id', sessionId)
+    .eq('order_index', orderIndex)
+    .maybeSingle();
+
+  if (existing) {
+    if (!existing.answer_deadline_at) {
+      await supabase
+        .schema('public')
+        .from('questions')
+        .update({ answer_deadline_at: answerDeadlineAt.toISOString(), phase: 'answering' })
+        .eq('id', existing.id);
+    }
+
+    return {
+      id: existing.id,
+      answerDeadlineAt: existing.answer_deadline_at ?? answerDeadlineAt.toISOString(),
+    };
+  }
+
+  const { data: created, error } = await supabase
+    .schema('public')
+    .from('questions')
+    .insert({
+      session_id: sessionId,
+      asked_by: userId,
+      options: ANSWER_OPTIONS,
+      order_index: orderIndex,
+      phase: 'answering',
+      launched_at: now.toISOString(),
+      answer_deadline_at: answerDeadlineAt.toISOString(),
+    })
+    .select('id, answer_deadline_at')
+    .single();
+
+  if (error || !created) {
+    throw new Error('question_create_failed');
+  }
+
+  return {
+    id: created.id,
+    answerDeadlineAt: created.answer_deadline_at ?? answerDeadlineAt.toISOString(),
+  };
+}
+
+export async function resolveSessionQuestion(
+  supabase: ReturnType<typeof createSupabaseServerClient>,
+  options: {
+    sessionId: string;
+    questionId?: string | null;
+    questionIndex: number;
+    userId: string;
+    session: Pick<SessionAccessSnapshot, 'timer_mode' | 'timer_seconds' | 'started_at'>;
+  },
+) {
+  const { sessionId, questionId, questionIndex, userId, session } = options;
+
+  if (questionId) {
+    const { data: existing } = await supabase
+      .schema('public')
+      .from('questions')
+      .select('id, answer_deadline_at')
+      .eq('id', questionId)
+      .eq('session_id', sessionId)
+      .maybeSingle();
+
+    if (existing?.id) {
+      return {
+        id: existing.id,
+        answerDeadlineAt: existing.answer_deadline_at,
+      };
+    }
+  }
+
+  return ensureQuestion(supabase, sessionId, questionIndex, userId, session);
+}
+
+export function getSessionRedirectPath(locale: AppLocale, sessionId: string, questionIndex?: number) {
+  const path = `/${locale}/sessions/${sessionId}`;
+  if (typeof questionIndex !== 'number') {
+    return path;
+  }
+
+  return `${path}?q=${questionIndex}`;
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,10 @@
 import createNextIntlPlugin from 'next-intl/plugin';
+import bundleAnalyzer from '@next/bundle-analyzer';
 
 const withNextIntl = createNextIntlPlugin('./i18n/request.ts');
+const withBundleAnalyzer = bundleAnalyzer({
+  enabled: process.env.ANALYZE === 'true',
+});
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -17,5 +21,5 @@ const nextConfig = {
   },
 };
 
-export default withNextIntl(nextConfig);
+export default withBundleAnalyzer(withNextIntl(nextConfig));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,12 @@
         "stripe": "^18.5.0"
       },
       "devDependencies": {
+        "@next/bundle-analyzer": "^16.2.4",
         "@types/node": "^22.10.2",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "autoprefixer": "^10.4.20",
+        "cross-env": "^10.1.0",
         "eslint": "^8.57.1",
         "eslint-config-next": "14.2.28",
         "eslint-config-prettier": "^9.1.0",
@@ -43,6 +45,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -78,6 +90,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -339,6 +358,16 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.2.4.tgz",
+      "integrity": "sha512-EAA9xTDv0P1IiUcZaASJJPkNDjRvL7OMTha6XN8MBzALYGfn7I52Mn7vRiyjVfNrtUPi2qiacY+eFVXe3lKCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "14.2.28",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.28.tgz",
@@ -557,6 +586,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -1338,6 +1374,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -1973,6 +2022,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2068,6 +2135,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2176,6 +2250,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -3297,6 +3378,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -3388,6 +3485,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
@@ -3769,6 +3873,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-regex": {
@@ -4227,6 +4341,16 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4582,6 +4706,16 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -5550,6 +5684,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6042,6 +6191,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -6319,6 +6478,66 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "analyze": "cross-env ANALYZE=true next build",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
@@ -22,10 +23,12 @@
     "stripe": "^18.5.0"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^16.2.4",
     "@types/node": "^22.10.2",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "autoprefixer": "^10.4.20",
+    "cross-env": "^10.1.0",
     "eslint": "^8.57.1",
     "eslint-config-next": "14.2.28",
     "eslint-config-prettier": "^9.1.0",

--- a/supabase/migrations/20260424170000_dashboard_session_confidence_breakdown_materialized_view.sql
+++ b/supabase/migrations/20260424170000_dashboard_session_confidence_breakdown_materialized_view.sql
@@ -1,0 +1,35 @@
+create materialized view public.dashboard_user_session_confidence_breakdown as
+select
+  a.user_id,
+  s.id as session_id,
+  coalesce(nullif(trim(s.name), ''), g.name, 'Session') as session_name,
+  s.scheduled_at,
+  count(*) filter (where a.confidence = 'low')::int as low_count,
+  count(*) filter (where a.confidence = 'medium')::int as medium_count,
+  count(*) filter (where a.confidence = 'high')::int as high_count
+from public.answers a
+join public.questions q on q.id = a.question_id
+join public.sessions s on s.id = q.session_id
+left join public.groups g on g.id = s.group_id
+where a.confidence in ('low', 'medium', 'high')
+group by a.user_id, s.id, coalesce(nullif(trim(s.name), ''), g.name, 'Session'), s.scheduled_at;
+
+create unique index if not exists idx_dashboard_user_session_confidence_breakdown_user_session
+  on public.dashboard_user_session_confidence_breakdown (user_id, session_id);
+
+create index if not exists idx_dashboard_user_session_confidence_breakdown_user_scheduled_at
+  on public.dashboard_user_session_confidence_breakdown (user_id, scheduled_at desc);
+
+grant select on public.dashboard_user_session_confidence_breakdown to authenticated;
+
+create or replace function public.refresh_dashboard_user_profile_analytics()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  refresh materialized view public.dashboard_user_profile_analytics;
+  refresh materialized view public.dashboard_user_session_confidence_breakdown;
+end;
+$$;

--- a/supabase/migrations/20260424193000_group_member_stats_view.sql
+++ b/supabase/migrations/20260424193000_group_member_stats_view.sql
@@ -1,0 +1,10 @@
+create or replace view public.group_member_stats
+with (security_invoker = true) as
+select
+  gm.group_id,
+  count(*)::bigint as member_count,
+  min(case when gm.is_founder then gm.user_id::text end)::uuid as founder_user_id
+from public.group_members gm
+group by gm.group_id;
+
+grant select on public.group_member_stats to authenticated;

--- a/supabase/migrations/20260424200000_dashboard_user_group_session_views.sql
+++ b/supabase/migrations/20260424200000_dashboard_user_group_session_views.sql
@@ -1,0 +1,31 @@
+create or replace view public.dashboard_user_groups
+with (security_invoker = true) as
+select
+  gm.user_id,
+  gm.group_id,
+  gm.is_founder,
+  g.name,
+  coalesce(gms.member_count, 0)::bigint as member_count
+from public.group_members gm
+join public.groups g on g.id = gm.group_id
+left join public.group_member_stats gms on gms.group_id = gm.group_id;
+
+create or replace view public.dashboard_user_sessions
+with (security_invoker = true) as
+select
+  gm.user_id,
+  s.id,
+  s.group_id,
+  s.name,
+  s.scheduled_at,
+  s.share_code,
+  s.status,
+  s.timer_mode,
+  s.timer_seconds,
+  s.leader_id,
+  s.question_goal
+from public.group_members gm
+join public.sessions s on s.group_id = gm.group_id;
+
+grant select on public.dashboard_user_groups to authenticated;
+grant select on public.dashboard_user_sessions to authenticated;

--- a/supabase/migrations/20260424203000_dashboard_user_sessions_with_counts.sql
+++ b/supabase/migrations/20260424203000_dashboard_user_sessions_with_counts.sql
@@ -1,0 +1,24 @@
+create or replace view public.dashboard_user_sessions
+with (security_invoker = true) as
+select
+  gm.user_id,
+  s.id,
+  s.group_id,
+  s.name,
+  s.scheduled_at,
+  s.share_code,
+  s.status,
+  s.timer_mode,
+  s.timer_seconds,
+  s.leader_id,
+  s.question_goal,
+  coalesce(dsqc.question_count, 0)::bigint as question_count,
+  coalesce(duac.answered_question_count, 0)::bigint as answered_question_count
+from public.group_members gm
+join public.sessions s on s.group_id = gm.group_id
+left join public.dashboard_session_question_counts dsqc on dsqc.session_id = s.id
+left join public.dashboard_user_session_answer_counts duac
+  on duac.session_id = s.id
+ and duac.user_id = gm.user_id;
+
+grant select on public.dashboard_user_sessions to authenticated;

--- a/supabase/migrations/20260424213000_session_runtime_access_view.sql
+++ b/supabase/migrations/20260424213000_session_runtime_access_view.sql
@@ -1,0 +1,19 @@
+create or replace view public.session_runtime_access
+with (security_invoker = true) as
+select
+  gm.user_id,
+  s.id as session_id,
+  s.group_id,
+  s.status,
+  s.leader_id,
+  s.timer_mode,
+  s.timer_seconds,
+  s.question_goal,
+  s.started_at,
+  gm.is_founder,
+  coalesce(gms.member_count, 0)::bigint as member_count
+from public.group_members gm
+join public.sessions s on s.group_id = gm.group_id
+left join public.group_member_stats gms on gms.group_id = gm.group_id;
+
+grant select on public.session_runtime_access to authenticated;

--- a/supabase/migrations/20260424230000_session_answer_write_optimizations.sql
+++ b/supabase/migrations/20260424230000_session_answer_write_optimizations.sql
@@ -1,0 +1,38 @@
+create index if not exists idx_questions_session_id_launched_at_order_desc
+  on public.questions (session_id, launched_at desc, order_index desc)
+  where launched_at is not null;
+
+create or replace function public.sync_user_questions_answered()
+returns trigger
+language plpgsql
+as $$
+begin
+  if tg_op = 'INSERT' then
+    update public.users
+    set questions_answered = questions_answered + 1
+    where id = new.user_id;
+
+    return new;
+  elsif tg_op = 'DELETE' then
+    update public.users
+    set questions_answered = greatest(questions_answered - 1, 0)
+    where id = old.user_id;
+
+    return old;
+  elsif tg_op = 'UPDATE' then
+    if old.user_id is distinct from new.user_id then
+      update public.users
+      set questions_answered = greatest(questions_answered - 1, 0)
+      where id = old.user_id;
+
+      update public.users
+      set questions_answered = questions_answered + 1
+      where id = new.user_id;
+    end if;
+
+    return new;
+  end if;
+
+  return null;
+end;
+$$;

--- a/supabase/migrations/20260424233000_performance_trace_logging_views.sql
+++ b/supabase/migrations/20260424233000_performance_trace_logging_views.sql
@@ -1,0 +1,52 @@
+insert into public.feature_flags (key, enabled, description)
+values
+  ('canUsePerformanceLogging', true, 'Enables persisted structured performance trace logging.')
+on conflict (key) do update
+set
+  enabled = excluded.enabled,
+  description = excluded.description;
+
+create view public.beta_performance_trace_logs_7d
+with (security_invoker = true) as
+select
+  al.id,
+  al.created_at,
+  al.locale,
+  al.user_id,
+  al.group_id,
+  al.session_id,
+  al.metadata ->> 'trace_name' as trace_name,
+  al.metadata ->> 'trace_group' as trace_group,
+  al.metadata ->> 'trace_kind' as trace_kind,
+  nullif(al.metadata ->> 'question_id', '') as question_id,
+  case
+    when jsonb_typeof(al.metadata -> 'question_index') = 'number'
+      then (al.metadata ->> 'question_index')::integer
+    else null
+  end as question_index,
+  nullif(al.metadata ->> 'submit_mode', '') as submit_mode,
+  case
+    when jsonb_typeof(al.metadata -> 'total_ms') = 'number'
+      then (al.metadata ->> 'total_ms')::integer
+    else null
+  end as total_ms,
+  al.metadata -> 'steps' as steps
+from public.app_logs al
+where al.event_name = 'performance_trace_recorded'
+  and al.created_at >= timezone('utc', now()) - interval '7 days';
+
+create view public.beta_app_velocity_7d
+with (security_invoker = true) as
+select
+  trace_name,
+  trace_group,
+  trace_kind,
+  count(*)::bigint as sample_count,
+  round(avg(total_ms)::numeric, 2) as avg_ms,
+  percentile_disc(0.5) within group (order by total_ms) as p50_ms,
+  percentile_disc(0.95) within group (order by total_ms) as p95_ms,
+  min(total_ms) as min_ms,
+  max(total_ms) as max_ms
+from public.beta_performance_trace_logs_7d
+where total_ms is not null
+group by trace_name, trace_group, trace_kind;


### PR DESCRIPTION
## Summary

This PR applies a broad performance pass across the authenticated app.

It reduces shell and bundle cost, trims dashboard/group loading work, and improves the session flow by replacing heavy answer submits with a lighter JSON mutation path.

## What changed

- reduced authenticated layout work and client i18n payload
- improved dashboard and group data loading paths
- reduced session route bundle weight
- replaced session answer submit redirects with a lighter `/api/sessions/[id]/answer` flow
- reduced runtime polling churn and deduplicated session runtime fetches
- added SQL/view/index optimizations for dashboard/session reads and answer writes
- refreshed performance analytics after answer saves so heatmap/performance data stay up to date

