### PR TITLE
Polish session flow and speed up answer saves

### DIFF
--- a/app/[locale]/dashboard/actions.ts
+++ b/app/[locale]/dashboard/actions.ts
@@ -572,7 +572,7 @@ export async function createDashboardSessionAction(formData: FormData) {
     .maybeSingle();
 
   if (existingOpenSession) {
-    redirect(withFeedback(sessionsPath, 'success', t('sessionScheduled')));
+    redirect(withFeedback(`/${locale}/sessions/${existingOpenSession.id}`, 'success', t('sessionScheduled')));
   }
 
   let shareCode = generateSessionShareCode();
@@ -648,9 +648,7 @@ export async function createDashboardSessionAction(formData: FormData) {
     }
   }
 
-  revalidatePath(`/${locale}/dashboard`);
-  revalidatePath(groupDashboardPath(locale, groupId));
-  redirect(withFeedback(sessionsPath, 'success', t('sessionScheduled')));
+  redirect(withFeedback(`/${locale}/sessions/${createdSession.id}`, 'success', t('sessionScheduled')));
 }
 
 export const createGroupSessionAction = createDashboardSessionAction;
@@ -712,8 +710,6 @@ export async function cancelDashboardSessionAction(formData: FormData) {
     },
   });
 
-  revalidatePath(`/${locale}/dashboard`);
-  revalidatePath(groupDashboardPath(locale, session.group_id));
   redirect(withFeedback(sessionReturnPath, 'success', t('actionSucceeded')));
 }
 

--- a/app/[locale]/sessions/[sessionId]/page.tsx
+++ b/app/[locale]/sessions/[sessionId]/page.tsx
@@ -19,7 +19,6 @@ import {
   finishReviewSessionAction,
   initializeSessionFlowAction,
   quitIncompleteSessionAction,
-  saveReviewAnswerAction,
 } from './actions';
 
 type SessionPageProps = {
@@ -154,7 +153,7 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
 
   if (isReview && question) {
     const reviewQuestion = question as ReviewQuestion;
-    const questionAnswers = data.allAnswers.filter((answer) => answer.question_id === question.id);
+    const questionAnswers = data.currentQuestionAnswers;
     const distribution = getDistribution(questionAnswers, data.members.length);
     const myReviewAnswer = questionAnswers.find((answer) => answer.user_id === user.id) ?? null;
     const canFinish = questions.filter((item) => (item as ReviewQuestion).correct_option).length >= questionGoal;
@@ -167,14 +166,18 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
       <main className="flex flex-1 flex-col">
         <FeedbackBanner message={searchParams.feedbackMessage} tone={searchParams.feedbackTone} />
         <header className="sticky top-0 z-20 border-b border-white/[0.07] bg-background/95 backdrop-blur">
-          <div className="mx-auto grid min-h-16 w-full max-w-[700px] grid-cols-[40px_minmax(0,1fr)_40px] items-center gap-3 px-4 py-3 sm:h-16 sm:py-0">
+          <div className="mx-auto flex min-h-16 w-full max-w-[700px] items-center gap-3 px-4 py-3 sm:grid sm:grid-cols-[40px_minmax(0,1fr)_40px] sm:py-0">
             <Link href="/dashboard?view=sessions" prefetch={false} className="inline-flex h-10 w-10 items-center justify-start text-slate-500 hover:text-white">
               <ArrowLeft className="h-4 w-4" aria-hidden="true" />
             </Link>
-            <p className="min-w-0 flex-1 text-center text-base font-extrabold text-white sm:text-lg">
+            <div className="min-w-0 flex-1 sm:hidden">
+              <p className="truncate text-sm font-semibold text-white">{data.session.name ?? data.group.name}</p>
+              <p className="text-xs font-medium text-slate-500">{t('reviewShort')}</p>
+            </div>
+            <p className="hidden min-w-0 flex-1 text-center text-base font-extrabold text-white sm:block sm:text-lg">
               {data.session.name ?? data.group.name} - {t('reviewShort')}
             </p>
-            <span aria-hidden="true" />
+            <span aria-hidden="true" className="hidden sm:block" />
           </div>
         </header>
 
@@ -189,7 +192,10 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
                 {'<'} {t('previous')}
               </Link>
             )}
-            <h1 className="text-2xl font-extrabold text-white">{t('questionNumber', { number: currentIndex + 1 })}</h1>
+            <h1 className="text-lg font-semibold text-white sm:text-2xl sm:font-extrabold">
+              <span className="sm:hidden">{currentIndex + 1}/{questionGoal}</span>
+              <span className="hidden sm:inline">{t('questionNumber', { number: currentIndex + 1 })}</span>
+            </h1>
             {isLastQuestion ? (
               <span className="opacity-40">
                 {t('next')} {'>'}
@@ -206,7 +212,21 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
               <BarChart3 className="h-4 w-4 text-brand" aria-hidden="true" />
               <h2 className="text-sm font-extrabold text-white">{t('distribution')}</h2>
             </div>
-            <div className="mt-8 grid grid-cols-3 gap-x-2 gap-y-4 min-[420px]:grid-cols-6">
+            <div className="mt-3 grid grid-cols-6 gap-1.5 sm:hidden">
+              {[...ANSWER_OPTIONS, '?'].map((option) => (
+                <div
+                  key={option}
+                  className={`inline-flex min-h-9 items-center justify-center rounded-[7px] border px-1 text-center text-[11px] font-semibold ${
+                    reviewQuestion.correct_option === option
+                      ? 'border-brand/35 bg-brand/10 text-brand'
+                      : 'border-white/[0.08] bg-[#121b2e] text-slate-400'
+                  }`}
+                >
+                  {option}-{distribution.get(option) ?? 0}
+                </div>
+              ))}
+            </div>
+            <div className="mt-8 hidden grid-cols-3 gap-x-2 gap-y-4 min-[420px]:grid-cols-6 sm:grid">
               {[...ANSWER_OPTIONS, '?'].map((option) => (
                 <div key={option} className="flex w-full flex-col items-center gap-1 text-center">
                   <span className={reviewQuestion.correct_option === option ? 'text-sm font-extrabold text-brand' : 'text-sm font-bold text-slate-500'}>
@@ -220,7 +240,6 @@ export default async function SessionPage({ params, searchParams }: SessionPageP
             <div className="mt-5 border-t border-white/[0.06] pt-5">
               <ReviewAnswerForm
                 key={question.id}
-                action={saveReviewAnswerAction}
                 locale={locale}
                 sessionId={params.sessionId}
                 questionId={question.id}

--- a/app/api/sessions/[sessionId]/answer/route.ts
+++ b/app/api/sessions/[sessionId]/answer/route.ts
@@ -138,12 +138,7 @@ export async function POST(request: Request, { params }: RouteContext) {
       { onConflict: 'question_id,user_id' },
     );
     perf.step('answer_upserted');
-    try {
-      await refreshDashboardProfileAnalytics();
-      perf.step('analytics_refreshed');
-    } catch {
-      // Preserve the saved answer even if analytics refresh is temporarily unavailable.
-    }
+    runDeferredTasks([refreshDashboardProfileAnalytics().catch(() => undefined)]);
     perf.done({ mode: 'timeout', questionId: ensuredQuestion.id });
 
     return NextResponse.json({
@@ -166,14 +161,9 @@ export async function POST(request: Request, { params }: RouteContext) {
     { onConflict: 'question_id,user_id' },
   );
   perf.step('answer_upserted');
-  try {
-    await refreshDashboardProfileAnalytics();
-    perf.step('analytics_refreshed');
-  } catch {
-    // Preserve the saved answer even if analytics refresh is temporarily unavailable.
-  }
 
   runDeferredTasks([
+    refreshDashboardProfileAnalytics().catch(() => undefined),
     logAppEvent({
       eventName: APP_EVENTS.answerSubmitted,
       locale,

--- a/app/api/sessions/[sessionId]/review-answer/route.ts
+++ b/app/api/sessions/[sessionId]/review-answer/route.ts
@@ -1,0 +1,151 @@
+import { NextResponse } from 'next/server';
+import { getTranslations } from 'next-intl/server';
+
+import type { AppLocale } from '@/i18n/routing';
+import { APP_EVENTS } from '@/lib/logging/events';
+import { logAppEvent } from '@/lib/logging/logger';
+import { createPerfTracker } from '@/lib/observability/perf';
+import { getCurrentAuthUser, getSessionAccessSnapshot, loadSessionRuntimeAccess } from '@/lib/session/flow';
+import { ANSWER_OPTIONS } from '@/lib/types/demo';
+
+type RouteContext = {
+  params: { sessionId: string };
+};
+
+type ReviewPayload = {
+  locale?: string;
+  questionId?: string | null;
+  questionIndex?: number;
+  nextQuestionIndex?: number;
+  advanceAfterSave?: boolean;
+  correctOption?: string | null;
+};
+
+export async function POST(request: Request, { params }: RouteContext) {
+  const sessionId = params.sessionId;
+  const body = (await request.json().catch(() => null)) as ReviewPayload | null;
+  const locale = (body?.locale ?? 'en') as AppLocale;
+  const questionId = body?.questionId?.trim() ?? '';
+  const questionIndex = Number(body?.questionIndex);
+  const nextQuestionIndex = Number(body?.nextQuestionIndex);
+  const advanceAfterSave = body?.advanceAfterSave === true;
+  const correctOption = body?.correctOption?.toUpperCase() ?? '';
+  const perf = createPerfTracker(`saveReviewAnswerRoute:${sessionId}:${questionIndex}`);
+  const t = await getTranslations({ locale, namespace: 'Feedback' });
+
+  if (!sessionId || !questionId || !Number.isInteger(questionIndex) || questionIndex < 0) {
+    return NextResponse.json({ ok: false, message: t('actionFailed') }, { status: 400 });
+  }
+
+  if (!ANSWER_OPTIONS.includes(correctOption as (typeof ANSWER_OPTIONS)[number])) {
+    return NextResponse.json({ ok: false, message: t('missingFields') }, { status: 400 });
+  }
+
+  const { supabase, user } = await getCurrentAuthUser();
+  perf.step('auth_loaded');
+
+  if (!user) {
+    return NextResponse.json(
+      { ok: false, redirectTo: `/${locale}/auth/login`, message: t('notAuthorized') },
+      { status: 401 },
+    );
+  }
+
+  const access = await loadSessionRuntimeAccess(supabase, sessionId, user.id);
+  perf.step('session_loaded');
+  const session = getSessionAccessSnapshot(access);
+
+  if (!session) {
+    return NextResponse.json(
+      { ok: false, redirectTo: `/${locale}/dashboard?view=sessions`, message: t('notAuthorized') },
+      { status: 403 },
+    );
+  }
+  perf.setContext({
+    locale,
+    userId: user.id,
+    groupId: session.group_id,
+    sessionId,
+    minDurationMs: 250,
+    metadata: {
+      trace_group: 'sessions',
+      trace_kind: 'review_save',
+      question_id: questionId,
+      question_index: questionIndex,
+      advance_after_save: advanceAfterSave,
+    },
+  });
+  perf.step('membership_loaded');
+
+  if (session.status !== 'incomplete' && session.status !== 'active' && session.status !== 'completed') {
+    return NextResponse.json({ ok: false, message: t('actionFailed') }, { status: 400 });
+  }
+
+  const { data: question } = await supabase
+    .schema('public')
+    .from('questions')
+    .select('id, session_id')
+    .eq('id', questionId)
+    .maybeSingle();
+  perf.step('question_loaded');
+
+  if (!question || question.session_id !== sessionId) {
+    return NextResponse.json({ ok: false, message: t('notAuthorized') }, { status: 403 });
+  }
+
+  await supabase
+    .schema('public')
+    .from('questions')
+    .update({ correct_option: correctOption, phase: 'review' })
+    .eq('id', questionId);
+  perf.step('question_updated');
+
+  await Promise.all([
+    supabase
+      .schema('public')
+      .from('answers')
+      .update({ is_correct: true })
+      .eq('question_id', questionId)
+      .eq('selected_option', correctOption),
+    supabase
+      .schema('public')
+      .from('answers')
+      .update({ is_correct: false })
+      .eq('question_id', questionId)
+      .neq('selected_option', correctOption),
+  ]);
+  perf.step('review_updates_saved');
+
+  void logAppEvent({
+    eventName: APP_EVENTS.answerRevealed,
+    locale,
+    userId: user.id,
+    groupId: session.group_id,
+    sessionId,
+    metadata: {
+      question_id: questionId,
+      correct_option: correctOption,
+      source: 'review_flow',
+    },
+  });
+  perf.step('deferred_side_effects_started');
+
+  const targetQuestionIndex =
+    advanceAfterSave && Number.isInteger(nextQuestionIndex)
+      ? Math.max(0, Math.min(nextQuestionIndex, Math.max(session.question_goal - 1, 0)))
+      : questionIndex;
+
+  const redirectTo = `/${locale}/sessions/${sessionId}?stage=review&q=${targetQuestionIndex}`;
+  perf.done({
+    questionId,
+    correctOption,
+    targetQuestionIndex,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    redirectTo,
+    correctOption,
+    targetQuestionIndex,
+  });
+}

--- a/components/session/session-flow-client.tsx
+++ b/components/session/session-flow-client.tsx
@@ -444,7 +444,6 @@ export function SessionAnswerForm({
 }
 
 export function ReviewAnswerForm({
-  action,
   locale,
   sessionId,
   questionId,
@@ -456,7 +455,6 @@ export function ReviewAnswerForm({
   participantConfidence,
   labels,
 }: {
-  action: ServerAction;
   locale: string;
   sessionId: string;
   questionId: string;
@@ -476,7 +474,10 @@ export function ReviewAnswerForm({
     reviewStatus: Record<CertaintyCorrectnessStatus, string>;
   };
 }) {
+  const router = useRouter();
   const [correctOption, setCorrectOption] = useState<AnswerOption | ''>(initialCorrectOption ?? '');
+  const [isPending, setIsPending] = useState(false);
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
   const canSubmit = Boolean(correctOption) && correctOption !== initialCorrectOption;
   const hasCorrectOption = Boolean(correctOption);
   const normalizedParticipantAnswer = participantAnswer?.toUpperCase() ?? '?';
@@ -497,6 +498,8 @@ export function ReviewAnswerForm({
 
   useEffect(() => {
     setCorrectOption(initialCorrectOption ?? '');
+    setIsPending(false);
+    setSubmissionError(null);
   }, [initialCorrectOption, questionId]);
 
   useEffect(() => {
@@ -517,15 +520,62 @@ export function ReviewAnswerForm({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
 
+  async function saveReviewAnswer() {
+    if (!canSubmit || isPending) {
+      return;
+    }
+
+    setSubmissionError(null);
+    setIsPending(true);
+
+    try {
+      const response = await fetch(`/api/sessions/${sessionId}/review-answer`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          locale,
+          questionId,
+          questionIndex,
+          nextQuestionIndex,
+          advanceAfterSave: !isLastQuestion,
+          correctOption,
+        }),
+      });
+
+      const payload = (await response.json().catch(() => ({ ok: false }))) as {
+        ok?: boolean;
+        message?: string;
+        redirectTo?: string;
+      };
+
+      if (!response.ok || !payload.ok) {
+        if (payload.redirectTo) {
+          router.replace(payload.redirectTo as never);
+          return;
+        }
+
+        setSubmissionError(payload.message ?? labels.savePending);
+        setIsPending(false);
+        return;
+      }
+
+      if (payload.redirectTo) {
+        router.replace(payload.redirectTo as never);
+        return;
+      }
+
+      setIsPending(false);
+    } catch {
+      setSubmissionError(labels.savePending);
+      setIsPending(false);
+    }
+  }
+
   return (
-    <form action={action} className="space-y-4">
-      <input type="hidden" name="locale" value={locale} />
-      <input type="hidden" name="sessionId" value={sessionId} />
-      <input type="hidden" name="questionId" value={questionId} />
-      <input type="hidden" name="questionIndex" value={questionIndex} />
-      <input type="hidden" name="nextQuestionIndex" value={nextQuestionIndex} />
-      <input type="hidden" name="advanceAfterSave" value={isLastQuestion ? 'false' : 'true'} />
-      <input type="hidden" name="correctOption" value={correctOption} />
+    <div className="space-y-4">
       <p className="text-sm font-bold text-slate-300">{labels.correctAnswer}</p>
       <div className="grid grid-cols-3 gap-2 min-[420px]:grid-cols-6">
         {[...ANSWER_OPTIONS, '?'].map((option) => (
@@ -533,13 +583,14 @@ export function ReviewAnswerForm({
             key={option}
             type="button"
             onClick={() => {
-              if (option !== '?') setCorrectOption(option as AnswerOption);
+              if (!isPending && option !== '?') setCorrectOption(option as AnswerOption);
             }}
             className={`h-11 w-full rounded-[7px] border text-base font-extrabold transition ${
               correctOption === option
                 ? 'border-brand bg-brand text-white'
                 : 'border-white/[0.08] bg-[#202b3e] text-slate-300 hover:border-brand/50'
             }`}
+            disabled={isPending}
           >
             {option}
           </button>
@@ -556,19 +607,33 @@ export function ReviewAnswerForm({
           </div>
         </section>
       ) : null}
-      <SubmitButton
-        pendingLabel={labels.savePending}
-        className="button-primary h-10 w-full rounded-[7px] py-2 text-sm disabled:bg-brand/40 disabled:text-white/60"
-        disabled={!canSubmit}
+      <button
+        type="button"
+        className="button-primary relative h-10 w-full rounded-[7px] py-2 text-sm disabled:cursor-not-allowed disabled:bg-brand/40 disabled:text-white/60 disabled:opacity-70"
+        disabled={!canSubmit || isPending}
+        onClick={() => {
+          void saveReviewAnswer();
+        }}
+        aria-disabled={!canSubmit || isPending}
+        aria-busy={isPending}
       >
-        {isLastQuestion
-          ? initialCorrectOption
-            ? labels.update
-            : labels.save
-          : initialCorrectOption
-            ? labels.updateAndNext
-            : labels.saveAndNext}
-      </SubmitButton>
-    </form>
+        <span className={isPending ? 'text-transparent' : ''}>
+          {isLastQuestion
+            ? initialCorrectOption
+              ? labels.update
+              : labels.save
+            : initialCorrectOption
+              ? labels.updateAndNext
+              : labels.saveAndNext}
+        </span>
+        {isPending ? (
+          <span className="absolute inset-0 inline-flex items-center justify-center gap-2">
+            <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
+            {labels.savePending}
+          </span>
+        ) : null}
+      </button>
+      {submissionError ? <p className="text-center text-sm font-semibold text-rose-300">{submissionError}</p> : null}
+    </div>
   );
 }

--- a/components/sessions/session-card.tsx
+++ b/components/sessions/session-card.tsx
@@ -99,6 +99,18 @@ export function SessionCard({
           <div className="flex min-w-0 flex-wrap items-center gap-2">
             <h2 className="truncate text-sm font-extrabold text-white">{session.name ?? session.groupName ?? 'ActiveBoard'}</h2>
             <StatusBadge status={session.status} labels={labels} />
+            <form action={cancelSessionAction} onClick={(event) => event.stopPropagation()}>
+              <input type="hidden" name="locale" value={locale} />
+              <input type="hidden" name="sessionId" value={session.id} />
+              {returnTo ? <input type="hidden" name="returnTo" value={returnTo} /> : null}
+              <SubmitButton
+                pendingLabel=""
+                className="rounded-md p-1.5 text-rose-300 transition hover:bg-white/[0.06] hover:text-rose-200"
+                disabled={session.status === 'completed' || session.status === 'cancelled'}
+              >
+                <Trash2 className="h-4 w-4" aria-hidden="true" strokeWidth={1.8} />
+              </SubmitButton>
+            </form>
           </div>
           <p className="mt-1 text-xs font-medium text-slate-500">
             {new Intl.DateTimeFormat(locale, {
@@ -121,19 +133,6 @@ export function SessionCard({
           >
             <Share2 className="h-4 w-4" aria-hidden="true" strokeWidth={1.8} />
           </button>
-          <form action={cancelSessionAction} onClick={(event) => event.stopPropagation()}>
-            <input type="hidden" name="locale" value={locale} />
-            <input type="hidden" name="sessionId" value={session.id} />
-            {returnTo ? <input type="hidden" name="returnTo" value={returnTo} /> : null}
-            <SubmitButton
-              pendingLabel=""
-              className="rounded-md p-1.5 transition hover:bg-white/[0.06] hover:text-red-300"
-              disabled={session.status === 'completed' || session.status === 'cancelled'}
-            >
-              <span className="sr-only">{labels.delete}</span>
-              <Trash2 className="h-4 w-4" aria-hidden="true" strokeWidth={1.8} />
-            </SubmitButton>
-          </form>
         </div>
       </div>
     </article>

--- a/lib/demo/data.ts
+++ b/lib/demo/data.ts
@@ -904,7 +904,7 @@ export const getGroupCoreData = cache(async (groupId: string, user: User) => {
       .order('start_time', { ascending: true }),
   ]);
 
-  const safeSessions = sessions ?? [];
+  const safeSessions = (sessions ?? []).filter((session) => session.status !== 'cancelled');
   const safeWeeklySchedules = sortWeeklySchedules(weeklySchedules ?? []);
   const memberCount = memberStats?.member_count ?? 0;
   const founderCaptainId = memberStats?.founder_user_id ?? null;
@@ -980,7 +980,7 @@ export const getGroupData = cache(async (groupId: string, user: User) => {
   ]);
   const safeInvites = invites ?? [];
   const safeMembers = members ?? [];
-  const safeSessions = sessions ?? [];
+  const safeSessions = (sessions ?? []).filter((session) => session.status !== 'cancelled');
   const safeWeeklySchedules = sortWeeklySchedules(weeklySchedules ?? []);
   const userIds = [...new Set([...safeMembers.map((member) => member.user_id), ...safeInvites.map((invite) => invite.invited_by)])];
   const usersMap = await getUsersMap(supabase, userIds);
@@ -1239,21 +1239,25 @@ export const getSessionPageData = cache(
       ]);
 
       const safeQuestions = questions ?? [];
-      const safeQuestionIds = safeQuestions.map((question) => question.id);
       const hasExplicitQuestionIndex = Number.isFinite(questionIndex);
       const firstPendingReviewQuestion =
         safeQuestions.find((question) => !question.correct_option) ?? safeQuestions[0] ?? null;
       const resolvedReviewIndex = hasExplicitQuestionIndex
         ? Math.max(0, Math.min(questionIndex as number, Math.max((session.question_goal ?? safeQuestions.length ?? 1) - 1, 0)))
         : (firstPendingReviewQuestion?.order_index ?? 0);
-      const safeAllAnswers =
-        safeQuestionIds.length > 0
+      const currentReviewQuestion =
+        safeQuestions.find((question) => question.order_index === resolvedReviewIndex) ??
+        safeQuestions[resolvedReviewIndex] ??
+        firstPendingReviewQuestion ??
+        null;
+      const currentQuestionAnswers =
+        currentReviewQuestion
           ? (
               await supabase
                 .schema('public')
                 .from('answers')
                 .select('id, question_id, user_id, selected_option, confidence, is_correct, answered_at')
-                .in('question_id', safeQuestionIds)
+                .eq('question_id', currentReviewQuestion.id)
             ).data ?? []
           : [];
 
@@ -1266,16 +1270,17 @@ export const getSessionPageData = cache(
         resolvedQuestionIndex: resolvedReviewIndex,
         questionGoal: session.question_goal ?? Math.max(safeQuestions.length, 10),
         questions: safeQuestions,
-        currentQuestion: null,
-        currentQuestionAnswers: [] as Array<{
+        currentQuestion: currentReviewQuestion,
+        currentQuestionAnswers,
+        allAnswers: [] as Array<{
           id: string;
+          question_id: string;
           user_id: string;
           selected_option: string | null;
           confidence: string | null;
           is_correct: boolean | null;
           answered_at: string | null;
         }>,
-        allAnswers: safeAllAnswers,
       };
     }
 


### PR DESCRIPTION
## Summary

This PR improves the session and review flows by cleaning up session card UX, filtering cancelled sessions from lists, and reducing answer save latency in both session room and review.

## What changed

- moved review answer saving to a lighter JSON route
- reduced review reload cost by loading only the current question answers during review
- deferred dashboard analytics refresh out of the hot answer-submit path
- redirected session creation directly to the created session screen
- filtered cancelled sessions from session/group lists
- refined session card actions layout


