### PR TITLE
Make dashboard and group tab navigation feel instant

### DIFF
--- a/app/[locale]/dashboard/page.tsx
+++ b/app/[locale]/dashboard/page.tsx
@@ -2,6 +2,7 @@ import { getTranslations } from 'next-intl/server';
 import { redirect } from 'next/navigation';
 
 import { FeedbackBanner } from '@/components/app/feedback-banner';
+import { DashboardViewShell } from '@/components/dashboard/dashboard-view-shell';
 import { DashboardPerformanceView } from '@/components/dashboard/dashboard-performance-view';
 import { DashboardSessionsView } from '@/components/dashboard/dashboard-sessions-view';
 import type { AppLocale } from '@/i18n/routing';
@@ -38,20 +39,130 @@ export default async function DashboardPage({ params, searchParams }: DashboardP
   }
 
   const view = searchParams.view === 'performance' ? 'performance' : 'sessions';
-  const isPerformanceView = view === 'performance';
   const isSessionsView = view === 'sessions';
   const isSessionJoinFeedback = isSessionsView && searchParams.sessionJoinFeedback === '1' && Boolean(searchParams.feedbackMessage);
 
   const [sessionsData, performanceData, accessState, billingSnapshot] = await Promise.all([
-    isSessionsView ? getDashboardSessionsData(user) : null,
-    isPerformanceView ? getDashboardPerformanceData(user.id) : null,
-    isSessionsView ? getUserAccessState(user.id) : null,
-    isSessionsView ? getUserBillingSnapshot(user.id) : null,
+    getDashboardSessionsData(user),
+    getDashboardPerformanceData(user.id),
+    getUserAccessState(user.id),
+    getUserBillingSnapshot(user.id),
   ]);
 
-  const canJoinSessions = isSessionsView && accessState ? hasUserTierCapability(accessState, 'canJoinSessions') : false;
-  const canCreateSession = isSessionsView && accessState ? hasUserTierCapability(accessState, 'canCreateSession') : false;
+  const canJoinSessions = hasUserTierCapability(accessState, 'canJoinSessions');
+  const canCreateSession = hasUserTierCapability(accessState, 'canCreateSession');
   const trialProgress = getTrialProgressSnapshot(billingSnapshot?.questions_answered ?? 0);
+
+  const sessionsProps = {
+    locale,
+    sessions: sessionsData?.sessions ?? [],
+    groups: (sessionsData?.groups ?? []).map((group) => ({
+      id: group.id,
+      name: group.name,
+      memberCount: group.memberCount,
+    })),
+    trialProgress,
+    canJoinSessions,
+    canCreateSession,
+    cancelSessionAction: cancelDashboardSessionAction,
+    joinSessionAction: joinSessionByCodeAction,
+    createSessionAction: createDashboardSessionAction,
+    sessionJoinFeedback:
+      isSessionJoinFeedback && searchParams.feedbackMessage && searchParams.feedbackTone
+        ? {
+            tone: searchParams.feedbackTone === 'success' ? 'success' : 'error',
+            message: searchParams.feedbackMessage,
+          }
+        : null,
+    labels: {
+      sessions: t('sessions'),
+      newSession: t('newSession'),
+      createSession: t('createSession'),
+      createSessionPending: t('createSessionPending'),
+      groupName: t('groupName'),
+      sessionName: t('sessionName'),
+      sessionNamePlaceholder: t('sessionNamePlaceholder'),
+      questionCount: t('questionCount'),
+      timerMode: t('timerMode'),
+      perQuestionMode: t('perQuestionMode'),
+      globalMode: t('globalMode'),
+      timerSeconds: t('timerSeconds'),
+      totalTimerSeconds: t('totalTimerSeconds'),
+      modalHint: t('modalHint'),
+      close: t('close'),
+      noSessionCta: t('noSessionCta'),
+      sessionCodePlaceholder: t('sessionCodePlaceholder'),
+      go: t('go'),
+      goPending: t('goPending'),
+      upgradeRequiredToJoinSession: feedbackT('upgradeRequiredToJoinSession'),
+      share: t('shareSession'),
+      delete: t('deleteSession'),
+      copied: t('copied'),
+      statusScheduled: t('statusScheduled'),
+      statusActive: t('statusActive'),
+      statusCompleted: t('statusCompleted'),
+      statusIncomplete: t('statusIncomplete'),
+      statusCancelled: t('statusCancelled'),
+      soloSessionProgressHint: t('soloSessionProgressHint'),
+      groupAccessHint: t('groupAccessHint'),
+      trialProgressTitle: t('trialProgressTitle'),
+      trialProgressSummary: t('trialProgressSummary', { current: '{current}', total: '{total}' }),
+      trialProgressDescription: t('trialProgressDescription', { remaining: '{remaining}' }),
+      trialProgressWarning: t('trialProgressWarning', { remaining: '{remaining}' }),
+      trialProgressComplete: t('trialProgressComplete'),
+    },
+  } satisfies React.ComponentProps<typeof DashboardSessionsView>;
+
+  const performanceProps = {
+    answeredCount: performanceData?.metrics.answeredCount ?? 0,
+    completedSessionsCount: performanceData?.metrics.completedSessionsCount ?? 0,
+    successRate: performanceData?.metrics.successRate ?? null,
+    averageConfidence: performanceData?.metrics.averageConfidence ?? null,
+    heatmap: performanceData?.profileAnalytics.heatmap ?? [],
+    confidenceCalibration: performanceData?.profileAnalytics.confidenceCalibration ?? [],
+    sessionConfidenceBreakdown: performanceData?.sessionConfidenceBreakdown ?? [],
+    labels: {
+      sprintActivityTitle: t('sprintActivityTitle'),
+      questionsAnswered: t('questionsAnswered'),
+      heatmapAvailableAfterSessions: t('heatmapAvailableAfterSessions'),
+      certaintyTitle: t('certaintyTitle'),
+      confidenceLow: t('confidenceLow'),
+      confidenceMedium: t('confidenceMedium'),
+      confidenceHigh: t('confidenceHigh'),
+      confidenceAfterNextSession: t('confidenceAfterNextSession'),
+      noData: t('noData'),
+      weekdays: [
+        t('weekdayShortMonday'),
+        t('weekdayShortTuesday'),
+        t('weekdayShortWednesday'),
+        t('weekdayShortThursday'),
+        t('weekdayShortFriday'),
+        t('weekdayShortSaturday'),
+        t('weekdayShortSunday'),
+      ],
+      monthLabels: [
+        t('monthJanuary'),
+        t('monthFebruary'),
+        t('monthMarch'),
+        t('monthApril'),
+        t('monthMay'),
+        t('monthJune'),
+        t('monthJuly'),
+        t('monthAugust'),
+        t('monthSeptember'),
+        t('monthOctober'),
+        t('monthNovember'),
+        t('monthDecember'),
+      ],
+      none: t('heatmapNone'),
+      less: t('heatmapLess'),
+      more: t('heatmapMore'),
+      sessionsFinished: t('sessionsFinished', { count: performanceData?.metrics.completedSessionsCount ?? 0 }),
+      averagePerWeek: t('averagePerWeek'),
+      completion: t('completion'),
+      confidenceCalibrationTitle: t('confidenceCalibrationTitle'),
+    },
+  } satisfies React.ComponentProps<typeof DashboardPerformanceView>;
   return (
     <main className="flex flex-1 flex-col gap-5">
       <FeedbackBanner
@@ -60,121 +171,11 @@ export default async function DashboardPage({ params, searchParams }: DashboardP
       />
 
       <section className="mx-auto w-full max-w-[620px] space-y-4">
-        {isSessionsView ? (
-          <DashboardSessionsView
-            locale={locale}
-            sessions={sessionsData?.sessions ?? []}
-            groups={(sessionsData?.groups ?? []).map((group) => ({
-              id: group.id,
-              name: group.name,
-              memberCount: group.memberCount,
-            }))}
-            trialProgress={trialProgress}
-            canJoinSessions={canJoinSessions}
-            canCreateSession={canCreateSession}
-            cancelSessionAction={cancelDashboardSessionAction}
-            joinSessionAction={joinSessionByCodeAction}
-            createSessionAction={createDashboardSessionAction}
-            sessionJoinFeedback={
-              isSessionJoinFeedback && searchParams.feedbackMessage && searchParams.feedbackTone
-                ? {
-                    tone: searchParams.feedbackTone === 'success' ? 'success' : 'error',
-                    message: searchParams.feedbackMessage,
-                  }
-                : null
-            }
-            labels={{
-              sessions: t('sessions'),
-              newSession: t('newSession'),
-              createSession: t('createSession'),
-              createSessionPending: t('createSessionPending'),
-              groupName: t('groupName'),
-              sessionName: t('sessionName'),
-              sessionNamePlaceholder: t('sessionNamePlaceholder'),
-              questionCount: t('questionCount'),
-              timerMode: t('timerMode'),
-              perQuestionMode: t('perQuestionMode'),
-              globalMode: t('globalMode'),
-              timerSeconds: t('timerSeconds'),
-              totalTimerSeconds: t('totalTimerSeconds'),
-              modalHint: t('modalHint'),
-              close: t('close'),
-              noSessionCta: t('noSessionCta'),
-              sessionCodePlaceholder: t('sessionCodePlaceholder'),
-              go: t('go'),
-              goPending: t('goPending'),
-              upgradeRequiredToJoinSession: feedbackT('upgradeRequiredToJoinSession'),
-              share: t('shareSession'),
-              delete: t('deleteSession'),
-              copied: t('copied'),
-              statusScheduled: t('statusScheduled'),
-              statusActive: t('statusActive'),
-              statusCompleted: t('statusCompleted'),
-              statusIncomplete: t('statusIncomplete'),
-              statusCancelled: t('statusCancelled'),
-              soloSessionProgressHint: t('soloSessionProgressHint'),
-              groupAccessHint: t('groupAccessHint'),
-              trialProgressTitle: t('trialProgressTitle'),
-              trialProgressSummary: t('trialProgressSummary', { current: '{current}', total: '{total}' }),
-              trialProgressDescription: t('trialProgressDescription', { remaining: '{remaining}' }),
-              trialProgressWarning: t('trialProgressWarning', { remaining: '{remaining}' }),
-              trialProgressComplete: t('trialProgressComplete'),
-            }}
-          />
-        ) : null}
-
-        {isPerformanceView ? (
-          <DashboardPerformanceView
-            answeredCount={performanceData?.metrics.answeredCount ?? 0}
-            completedSessionsCount={performanceData?.metrics.completedSessionsCount ?? 0}
-            successRate={performanceData?.metrics.successRate ?? null}
-            averageConfidence={performanceData?.metrics.averageConfidence ?? null}
-            heatmap={performanceData?.profileAnalytics.heatmap ?? []}
-            confidenceCalibration={performanceData?.profileAnalytics.confidenceCalibration ?? []}
-            sessionConfidenceBreakdown={performanceData?.sessionConfidenceBreakdown ?? []}
-            labels={{
-              sprintActivityTitle: t('sprintActivityTitle'),
-              questionsAnswered: t('questionsAnswered'),
-              heatmapAvailableAfterSessions: t('heatmapAvailableAfterSessions'),
-              certaintyTitle: t('certaintyTitle'),
-              confidenceLow: t('confidenceLow'),
-              confidenceMedium: t('confidenceMedium'),
-              confidenceHigh: t('confidenceHigh'),
-              confidenceAfterNextSession: t('confidenceAfterNextSession'),
-              noData: t('noData'),
-              weekdays: [
-                t('weekdayShortMonday'),
-                t('weekdayShortTuesday'),
-                t('weekdayShortWednesday'),
-                t('weekdayShortThursday'),
-                t('weekdayShortFriday'),
-                t('weekdayShortSaturday'),
-                t('weekdayShortSunday'),
-              ],
-              monthLabels: [
-                t('monthJanuary'),
-                t('monthFebruary'),
-                t('monthMarch'),
-                t('monthApril'),
-                t('monthMay'),
-                t('monthJune'),
-                t('monthJuly'),
-                t('monthAugust'),
-                t('monthSeptember'),
-                t('monthOctober'),
-                t('monthNovember'),
-                t('monthDecember'),
-              ],
-              none: t('heatmapNone'),
-              less: t('heatmapLess'),
-              more: t('heatmapMore'),
-              sessionsFinished: t('sessionsFinished', { count: performanceData?.metrics.completedSessionsCount ?? 0 }),
-              averagePerWeek: t('averagePerWeek'),
-              completion: t('completion'),
-              confidenceCalibrationTitle: t('confidenceCalibrationTitle'),
-            }}
-          />
-        ) : null}
+        <DashboardViewShell
+          initialView={view}
+          sessionsProps={sessionsProps}
+          performanceProps={performanceProps}
+        />
       </section>
     </main>
   );

--- a/app/[locale]/groups/[groupId]/page.tsx
+++ b/app/[locale]/groups/[groupId]/page.tsx
@@ -6,6 +6,7 @@ import type { AppLocale } from '@/i18n/routing';
 import { requireUser } from '@/lib/auth';
 import { getUserAccessState, hasUserTierCapability } from '@/lib/billing/gating';
 import { getGroupCoreData } from '@/lib/demo/data';
+import { getGroupMemberPerformance, getGroupWeeklyProgress, getShellGroupsForUser } from '@/lib/groups/server';
 
 import {
   addDashboardExistingMemberAction,
@@ -38,12 +39,16 @@ export default async function GroupRoutePage({
 }) {
   const locale = params.locale as AppLocale;
   const user = await requireUser(locale);
-  const t = await getTranslations('Dashboard');
-  const accessState = await getUserAccessState(user.id);
+  const [t, accessState, data, shellGroups, memberPerformance, weeklyProgress] = await Promise.all([
+    getTranslations('Dashboard'),
+    getUserAccessState(user.id),
+    getGroupCoreData(params.groupId, user),
+    getShellGroupsForUser(user.id, locale),
+    getGroupMemberPerformance(params.groupId, user.email ?? ''),
+    getGroupWeeklyProgress(params.groupId),
+  ]);
   const canBrowseLookupLayer = hasUserTierCapability(accessState, 'canBrowseLookupLayer');
   const canCreateSession = hasUserTierCapability(accessState, 'canCreateSession');
-
-  const data = await getGroupCoreData(params.groupId, user);
 
   if (!data) {
     return null;
@@ -84,7 +89,7 @@ export default async function GroupRoutePage({
       <section className="mx-auto w-full max-w-[620px] space-y-4">
         <GroupPageView
           locale={locale}
-          shellGroups={[]}
+          shellGroups={shellGroups}
           currentUserInitials={getInitials(displayName)}
           canBrowseLookupLayer={canBrowseLookupLayer}
           initialLiveOpen={searchParams.live === '1'}
@@ -92,8 +97,8 @@ export default async function GroupRoutePage({
           isPrimaryGroupFounder={Boolean(data.membership.is_founder)}
           currentCaptainId={currentCaptainId}
           schedules={data.weeklySchedules}
-          initialWeeklyProgress={null}
-          memberPerformance={[]}
+          initialWeeklyProgress={weeklyProgress}
+          memberPerformance={memberPerformance}
           weekdayLabels={weekdayLabels}
           groupInfoSummary={groupInfoSummary}
           sessions={data.sessions}

--- a/components/dashboard/dashboard-view-shell.tsx
+++ b/components/dashboard/dashboard-view-shell.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { DashboardPerformanceView } from '@/components/dashboard/dashboard-performance-view';
+import { DashboardSessionsView } from '@/components/dashboard/dashboard-sessions-view';
+
+type DashboardView = 'sessions' | 'performance';
+
+type DashboardViewShellProps = {
+  initialView: DashboardView;
+  sessionsProps: React.ComponentProps<typeof DashboardSessionsView>;
+  performanceProps: React.ComponentProps<typeof DashboardPerformanceView>;
+};
+
+function getViewFromLocation(): DashboardView {
+  if (typeof window === 'undefined') {
+    return 'sessions';
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  return params.get('view') === 'performance' ? 'performance' : 'sessions';
+}
+
+export function DashboardViewShell({
+  initialView,
+  sessionsProps,
+  performanceProps,
+}: DashboardViewShellProps) {
+  const [view, setView] = useState<DashboardView>(initialView);
+
+  useEffect(() => {
+    setView(initialView);
+  }, [initialView]);
+
+  useEffect(() => {
+    function handleDashboardView(event: Event) {
+      const detail = (event as CustomEvent<{ view?: DashboardView }>).detail;
+      const nextView = detail?.view === 'performance' ? 'performance' : 'sessions';
+      setView(nextView);
+    }
+
+    function handlePopState() {
+      setView(getViewFromLocation());
+    }
+
+    window.addEventListener('activeboard:dashboard-view', handleDashboardView as EventListener);
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      window.removeEventListener('activeboard:dashboard-view', handleDashboardView as EventListener);
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, []);
+
+  return view === 'performance' ? (
+    <DashboardPerformanceView {...performanceProps} />
+  ) : (
+    <DashboardSessionsView {...sessionsProps} />
+  );
+}

--- a/components/groups/group-page-view.tsx
+++ b/components/groups/group-page-view.tsx
@@ -192,7 +192,7 @@ export function GroupPageView({
   const [isCreateSessionOpen, setIsCreateSessionOpen] = useState(false);
   const [resolvedShellGroups, setResolvedShellGroups] = useState(shellGroups);
   const [resolvedMemberPerformance, setResolvedMemberPerformance] = useState(memberPerformance);
-  const [memberPerformanceLoaded, setMemberPerformanceLoaded] = useState(memberPerformance.length > 0);
+  const [memberPerformanceLoaded, setMemberPerformanceLoaded] = useState(true);
   const [weeklyProgress, setWeeklyProgress] = useState(
     initialWeeklyProgress ?? {
       weeklyCompletedQuestions: 0,
@@ -247,6 +247,11 @@ export function GroupPageView({
     );
     setWeeklyProgressLoaded(Boolean(initialWeeklyProgress));
   }, [initialWeeklyProgress, schedules]);
+
+  useEffect(() => {
+    setResolvedMemberPerformance(memberPerformance);
+    setMemberPerformanceLoaded(true);
+  }, [memberPerformance]);
 
   useEffect(() => {
     if (!primaryGroup || memberPerformanceLoaded) {

--- a/components/layout/app-bottom-nav.tsx
+++ b/components/layout/app-bottom-nav.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { BarChart3, Play, Users, type LucideIcon } from 'lucide-react';
+import { useEffect, useMemo, useState, useTransition } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 
-import { Link } from '@/i18n/navigation';
+import { useRouter } from '@/i18n/navigation';
 import { cn } from '@/lib/utils';
 
 type AppBottomNavProps = {
@@ -26,36 +27,93 @@ type NavItem = {
 export function AppBottomNav({ locale, showGroupTab = true, groupsHref = '/groups', labels }: AppBottomNavProps) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [pendingKey, setPendingKey] = useState<NavItem['key'] | null>(null);
+  const [optimisticDashboardView, setOptimisticDashboardView] = useState<'sessions' | 'performance'>('sessions');
   const dashboardView = searchParams.get('view') ?? 'sessions';
   const isDashboardPath = pathname === `/${locale}/dashboard` || pathname === '/dashboard';
   const isGroupsPath = pathname === `/${locale}/groups` || pathname.startsWith(`/${locale}/groups/`) || pathname === '/groups';
-  const items: NavItem[] = [
-    {
-      key: 'sessions',
-      href: '/dashboard?view=sessions',
-      Icon: Play,
-    },
-    {
-      key: 'performance',
-      href: '/dashboard?view=performance',
-      Icon: BarChart3,
-    },
-  ];
+  const items = useMemo<NavItem[]>(() => {
+    const nextItems: NavItem[] = [
+      {
+        key: 'sessions',
+        href: '/dashboard?view=sessions',
+        Icon: Play,
+      },
+      {
+        key: 'performance',
+        href: '/dashboard?view=performance',
+        Icon: BarChart3,
+      },
+    ];
 
-  if (showGroupTab) {
-    items.push({
-      key: 'group',
-      href: groupsHref,
-      Icon: Users,
-    });
-  }
+    if (showGroupTab) {
+      nextItems.push({
+        key: 'group',
+        href: groupsHref,
+        Icon: Users,
+      });
+    }
+
+    return nextItems;
+  }, [groupsHref, showGroupTab]);
+
+  useEffect(() => {
+    setPendingKey(null);
+  }, [pathname, searchParams]);
+
+  useEffect(() => {
+    if (dashboardView === 'performance') {
+      setOptimisticDashboardView('performance');
+      return;
+    }
+
+    setOptimisticDashboardView('sessions');
+  }, [dashboardView]);
+
+  useEffect(() => {
+    function handleDashboardView(event: Event) {
+      const detail = (event as CustomEvent<{ view?: 'sessions' | 'performance' }>).detail;
+      setOptimisticDashboardView(detail?.view === 'performance' ? 'performance' : 'sessions');
+      setPendingKey(null);
+    }
+
+    window.addEventListener('activeboard:dashboard-view', handleDashboardView as EventListener);
+    return () => {
+      window.removeEventListener('activeboard:dashboard-view', handleDashboardView as EventListener);
+    };
+  }, []);
+
+  useEffect(() => {
+    const prefetchAll = () => {
+      for (const item of items) {
+        router.prefetch(item.href);
+      }
+    };
+
+    const idleWindow = window as Window & {
+      requestIdleCallback?: (callback: IdleRequestCallback) => number;
+      cancelIdleCallback?: (handle: number) => void;
+    };
+
+    if (typeof idleWindow.requestIdleCallback === 'function') {
+      const idleId = idleWindow.requestIdleCallback(() => prefetchAll());
+      return () => idleWindow.cancelIdleCallback?.(idleId);
+    }
+
+    const timeoutId = window.setTimeout(prefetchAll, 0);
+    return () => window.clearTimeout(timeoutId);
+  }, [items, router]);
 
   return (
     <nav className="fixed inset-x-0 bottom-0 z-40 border-t border-white/10 bg-[#060a16]/95 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 backdrop-blur-xl sm:px-3 sm:pb-[calc(0.75rem+env(safe-area-inset-bottom))]">
       <div className={cn('mx-auto grid max-w-[520px] gap-1', showGroupTab ? 'grid-cols-3' : 'grid-cols-2')}>
         {items.map((item) => {
           const Icon = item.Icon;
-          const active = item.key === 'group' ? isGroupsPath : isDashboardPath && dashboardView === item.key;
+          const active =
+            pendingKey === item.key ||
+            (item.key === 'group' ? isGroupsPath : isDashboardPath && optimisticDashboardView === item.key);
           const className = cn(
             'flex min-h-[60px] flex-col items-center justify-center gap-1 rounded-[10px] border px-1.5 text-[10px] font-medium transition sm:text-[11px]',
             active && 'border-brand/80 bg-brand/[0.12] text-brand shadow-[inset_0_0_0_1px_rgba(16,185,129,0.42),0_0_18px_rgba(16,185,129,0.12)]',
@@ -76,15 +134,32 @@ export function AppBottomNav({ locale, showGroupTab = true, groupsHref = '/group
           }
 
           return (
-            <Link
+            <button
               key={item.key}
-              href={item.href}
-              prefetch={false}
+              type="button"
               className={className}
+              disabled={isPending}
+              onMouseEnter={() => router.prefetch(item.href)}
+              onTouchStart={() => router.prefetch(item.href)}
+              onClick={() => {
+                if (isDashboardPath && item.key !== 'group') {
+                  const nextHref = `/${locale}/dashboard?view=${item.key}`;
+                  setOptimisticDashboardView(item.key);
+                  setPendingKey(null);
+                  window.history.pushState({}, '', nextHref);
+                  window.dispatchEvent(new CustomEvent('activeboard:dashboard-view', { detail: { view: item.key } }));
+                  return;
+                }
+
+                setPendingKey(item.key);
+                startTransition(() => {
+                  router.push(item.href);
+                });
+              }}
             >
               <Icon className="h-5 w-5" aria-hidden="true" />
               <span>{labels[item.key]}</span>
-            </Link>
+            </button>
           );
         })}
       </div>


### PR DESCRIPTION
## Summary

This PR improves perceived navigation speed between bottom tabs by making dashboard view switching instant on the client and by reducing unnecessary group-page loading work.

## What changed

- added a client dashboard view shell for instant `Sessions` / `Performance` switching
- updated bottom navigation to prefetch routes and switch dashboard tabs without a full server round-trip
- loaded group shell/performance/weekly progress more efficiently
- removed unnecessary follow-up client fetch behavior on the group page

