### PR TITLE
Fix session advance permissions for non-captains

### DIFF
--- a/app/[locale]/sessions/[sessionId]/actions.ts
+++ b/app/[locale]/sessions/[sessionId]/actions.ts
@@ -407,6 +407,10 @@ export async function advanceSessionStepAction(formData: FormData) {
     await redirectSessionActionError(locale, sessionId, 'actionFailed');
   }
 
+  if (session.leader_id !== user.id) {
+    await redirectSessionActionError(locale, sessionId, 'notAuthorized');
+  }
+
   const nextIndex = questionIndex + 1;
   if (nextIndex >= session.question_goal) {
     await supabase

--- a/app/[locale]/sessions/[sessionId]/page.tsx
+++ b/app/[locale]/sessions/[sessionId]/page.tsx
@@ -86,6 +86,7 @@ export default async function SessionPage({
       answeredCount >= questionGoal &&
       searchParams.stage !== 'review');
   const isReview = searchParams.stage === 'review';
+  const canAdvanceQuestion = data.session.leader_id === user.id;
 
   if (data.session.status === 'scheduled') {
     const timerLabel =
@@ -131,6 +132,7 @@ export default async function SessionPage({
             nextQuestion: t('nextQuestion'),
             nextQuestionPending: t('nextQuestionPending'),
             allAnswersReceived: t('allAnswersSubmitted'),
+            waitingForCaptainAdvance: t('waitingForCaptainAdvance'),
             allAnswersSubmitted: t('allAnswersSubmitted'),
             questionsCompletedValue: t('questionsCompletedValue', {
               current: questionGoal,
@@ -291,6 +293,7 @@ export default async function SessionPage({
         timerMode={data.session.timer_mode}
         timerSeconds={data.session.timer_seconds}
         startedAt={data.session.started_at}
+        canAdvanceQuestion={canAdvanceQuestion}
         initialAnswer={myAnswer?.selected_option}
         initialConfidence={
           myAnswer?.confidence as ConfidenceLevel | null | undefined
@@ -311,6 +314,7 @@ export default async function SessionPage({
           nextQuestion: t('nextQuestion'),
           nextQuestionPending: t('nextQuestionPending'),
           allAnswersReceived: t('allAnswersSubmitted'),
+          waitingForCaptainAdvance: t('waitingForCaptainAdvance'),
           allAnswersSubmitted: t('allAnswersSubmitted'),
           questionsCompletedValue: t('questionsCompletedValue', {
             current: questionGoal,

--- a/app/api/sessions/[sessionId]/advance/route.ts
+++ b/app/api/sessions/[sessionId]/advance/route.ts
@@ -102,6 +102,13 @@ export async function POST(request: Request, { params }: RouteContext) {
     },
   });
 
+  if (session.leader_id !== user.id) {
+    return NextResponse.json(
+      { ok: false, message: await getFeedback('captainOnlyAction') },
+      { status: 403 },
+    );
+  }
+
   if (session.status !== 'active' || questionIndex >= session.question_goal) {
     return NextResponse.json(
       { ok: false, message: await getFeedback('actionFailed') },

--- a/components/session/session-active-runtime.tsx
+++ b/components/session/session-active-runtime.tsx
@@ -25,6 +25,7 @@ type SessionActiveRuntimeProps = {
   timerMode: 'per_question' | 'global';
   timerSeconds: number;
   startedAt: string | null;
+  canAdvanceQuestion: boolean;
   initialSubmittedCount: number;
   initialMemberCount: number;
   initialAnswerDeadlineAt: string | null;
@@ -44,6 +45,7 @@ type SessionActiveRuntimeProps = {
     nextQuestion: string;
     nextQuestionPending: string;
     allAnswersReceived: string;
+    waitingForCaptainAdvance: string;
     allAnswersSubmitted: string;
     questionsCompletedValue: string;
     goToReview: string;
@@ -66,6 +68,7 @@ export function SessionActiveRuntime({
   timerMode,
   timerSeconds,
   startedAt,
+  canAdvanceQuestion,
   initialSubmittedCount,
   initialMemberCount,
   initialAnswerDeadlineAt,
@@ -323,6 +326,7 @@ export function SessionActiveRuntime({
           answerDeadlineAt={answerDeadlineAt}
           submittedCount={submittedCount}
           memberCount={memberCount}
+          canAdvanceQuestion={canAdvanceQuestion}
           onSubmissionStateChange={setIsSubmitting}
           onAnswerPersisted={(
             savedAnswer,
@@ -415,6 +419,7 @@ export function SessionActiveRuntime({
             nextQuestion: labels.nextQuestion,
             nextQuestionPending: labels.nextQuestionPending,
             allAnswersReceived: labels.allAnswersReceived,
+            waitingForCaptainAdvance: labels.waitingForCaptainAdvance,
           }}
         />
       </section>

--- a/components/session/session-flow-client.tsx
+++ b/components/session/session-flow-client.tsx
@@ -310,6 +310,7 @@ export function SessionAnswerForm({
   onQuestionAdvanced,
   onSessionCompleted,
   onQuestionAdvanceFailed,
+  canAdvanceQuestion,
   labels,
 }: {
   advanceAction: ServerAction;
@@ -337,6 +338,7 @@ export function SessionAnswerForm({
   }) => void;
   onSessionCompleted?: (href: string) => void;
   onQuestionAdvanceFailed?: () => void;
+  canAdvanceQuestion: boolean;
   labels: {
     confidenceTitle: string;
     confidenceLow: string;
@@ -349,6 +351,7 @@ export function SessionAnswerForm({
     nextQuestion: string;
     nextQuestionPending: string;
     allAnswersReceived: string;
+    waitingForCaptainAdvance: string;
   };
 }) {
   const router = useRouter();
@@ -875,30 +878,36 @@ export function SessionAnswerForm({
           <div className="text-center text-sm font-bold text-brand">
             {labels.allAnswersReceived}
           </div>
-          <button
-            type="button"
-            disabled={advanceStatus === 'saving'}
-            onClick={() => {
-              void advanceToNextQuestion();
-            }}
-            className="relative h-10 w-full rounded-[7px] bg-[#223047] px-4 py-2 text-sm font-extrabold text-white transition hover:bg-[#2a3a55] disabled:cursor-not-allowed disabled:opacity-70"
-            aria-busy={advanceStatus === 'saving'}
-          >
-            <span
-              className={advanceStatus === 'saving' ? 'text-transparent' : ''}
+          {canAdvanceQuestion ? (
+            <button
+              type="button"
+              disabled={advanceStatus === 'saving'}
+              onClick={() => {
+                void advanceToNextQuestion();
+              }}
+              className="relative h-10 w-full rounded-[7px] bg-[#223047] px-4 py-2 text-sm font-extrabold text-white transition hover:bg-[#2a3a55] disabled:cursor-not-allowed disabled:opacity-70"
+              aria-busy={advanceStatus === 'saving'}
             >
-              {labels.nextQuestion} <span aria-hidden="true">&gt;</span>
-            </span>
-            {advanceStatus === 'saving' ? (
-              <span className="absolute inset-0 inline-flex items-center justify-center gap-2">
-                <span
-                  className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
-                  aria-hidden="true"
-                />
-                {labels.nextQuestionPending}
+              <span
+                className={advanceStatus === 'saving' ? 'text-transparent' : ''}
+              >
+                {labels.nextQuestion} <span aria-hidden="true">&gt;</span>
               </span>
-            ) : null}
-          </button>
+              {advanceStatus === 'saving' ? (
+                <span className="absolute inset-0 inline-flex items-center justify-center gap-2">
+                  <span
+                    className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+                    aria-hidden="true"
+                  />
+                  {labels.nextQuestionPending}
+                </span>
+              ) : null}
+            </button>
+          ) : (
+            <p className="rounded-[7px] border border-white/[0.08] bg-[#101827] px-3 py-2 text-center text-xs font-bold text-slate-400">
+              {labels.waitingForCaptainAdvance}
+            </p>
+          )}
         </>
       ) : null}
     </div>

--- a/components/session/session-start-runtime.tsx
+++ b/components/session/session-start-runtime.tsx
@@ -40,6 +40,7 @@ type SessionStartRuntimeProps = {
     nextQuestion: string;
     nextQuestionPending: string;
     allAnswersReceived: string;
+    waitingForCaptainAdvance: string;
     allAnswersSubmitted: string;
     questionsCompletedValue: string;
     goToReview: string;
@@ -100,6 +101,7 @@ export function SessionStartRuntime({
         timerMode={timerMode}
         timerSeconds={timerSeconds}
         startedAt={activeQuestion.startedAt}
+        canAdvanceQuestion={true}
         initialAnswer={null}
         initialConfidence={null as ConfidenceLevel | null}
         initialSubmittedCount={0}
@@ -118,6 +120,7 @@ export function SessionStartRuntime({
           nextQuestion: labels.nextQuestion,
           nextQuestionPending: labels.nextQuestionPending,
           allAnswersReceived: labels.allAnswersReceived,
+          waitingForCaptainAdvance: labels.waitingForCaptainAdvance,
           allAnswersSubmitted: labels.allAnswersSubmitted,
           questionsCompletedValue: labels.questionsCompletedValue,
           goToReview: labels.goToReview,

--- a/messages/en.json
+++ b/messages/en.json
@@ -602,6 +602,7 @@
     "nextQuestion": "Next question",
     "nextQuestionPending": "Saving...",
     "allAnswersSubmitted": "All answers submitted!",
+    "waitingForCaptainAdvance": "Waiting for the captain to continue.",
     "questionsCompletedValue": "{current}/{total} questions completed",
     "goToReview": "Go to review",
     "quitSession": "Quit",
@@ -981,6 +982,7 @@
     "questionActive": "Finish the current question before launching a new one.",
     "questionClosed": "This question is no longer accepting answers.",
     "answerWindowClosed": "The answer timer has expired for this question.",
+    "captainOnlyAction": "Only the session captain can do this.",
     "minimumMembers": "At least 2 group members are required to start a session.",
     "minimumMembersRequired": "Minimum 2 members required to start a session."
   }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -602,6 +602,7 @@
                     "nextQuestion":  "Question suivante",
                     "nextQuestionPending":  "Sauvegarde...",
                     "allAnswersSubmitted":  "Toutes les réponses soumises !",
+                    "waitingForCaptainAdvance":  "En attente du capitaine pour continuer.",
                     "questionsCompletedValue":  "{current}/{total} questions complétées",
                     "goToReview":  "Passer à la révision",
                     "quitSession":  "Quitter",
@@ -981,6 +982,7 @@
                      "questionActive":  "Termine la question en cours avant d\u0027en lancer une autre.",
                      "questionClosed":  "Cette question n\u0027accepte plus de réponses.",
                      "answerWindowClosed":  "Le temps de réponse est écoulé pour cette question.",
+                    "captainOnlyAction":  "Seul le capitaine de la session peut faire cette action.",
                     "minimumMembers":  "Au moins 2 membres du groupe sont nécessaires pour démarrer une session.",
                     "minimumMembersRequired":  "Minimum 2 membres requis pour démarrer une session."
                 }


### PR DESCRIPTION


## Summary
- Restricts question advance to the session captain on the API route.
- Applies the same guard to the legacy server action path.
- Shows a waiting state for non-captains instead of exposing an advance action.


