### PR TITLE
 Aggregate review answer payloads

### DIFF
--- a/app/[locale]/sessions/[sessionId]/page.tsx
+++ b/app/[locale]/sessions/[sessionId]/page.tsx
@@ -187,7 +187,6 @@ export default async function SessionPage({
 
   if (isReview && question) {
     const reviewQuestion = question as ReviewQuestion;
-    const questionAnswers = data.currentQuestionAnswers;
     const reviewedQuestionCount =
       'reviewedQuestionCount' in data &&
       typeof data.reviewedQuestionCount === 'number'
@@ -206,13 +205,12 @@ export default async function SessionPage({
           locale={locale}
           sessionId={params.sessionId}
           sessionTitle={data.session.name ?? data.group.name}
-          userId={user.id}
           questionGoal={questionGoal}
-          memberCount={data.members.length}
           initialQuestionIndex={currentIndex}
           initialReviewedQuestionCount={reviewedQuestionCount}
           initialQuestion={reviewQuestion}
-          initialAnswers={questionAnswers}
+          initialDistribution={data.currentQuestionDistribution}
+          initialOwnAnswer={data.currentUserAnswer}
           labels={{
             reviewShort: t('reviewShort'),
             previous: t('previous'),
@@ -261,16 +259,13 @@ export default async function SessionPage({
     );
   }
 
-  const myAnswer =
-    data.currentQuestionAnswers.find((answer) => answer.user_id === user.id) ??
-    null;
-  const questionAnswers = data.currentQuestionAnswers;
+  const myAnswer = data.currentUserAnswer;
   const isQuestionExpired =
     Boolean(question.answer_deadline_at) &&
     new Date(question.answer_deadline_at ?? '').getTime() <= Date.now();
   const submittedCount = isQuestionExpired
     ? memberCount
-    : questionAnswers.length;
+    : data.currentQuestionSubmittedCount;
 
   return (
     <main className="flex flex-1 flex-col">

--- a/app/api/sessions/[sessionId]/review-question/route.ts
+++ b/app/api/sessions/[sessionId]/review-question/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { computeAnswerDistribution } from '@/lib/demo/distribution';
 import { createPerfTracker } from '@/lib/observability/perf';
 import {
   getCurrentAuthUser,
@@ -38,12 +39,7 @@ export async function GET(request: Request, { params }: RouteContext) {
     return NextResponse.json({ ok: false }, { status: 401 });
   }
 
-  const access = await loadSessionRuntimeAccess(
-    supabase,
-    sessionId,
-    user.id,
-    false,
-  );
+  const access = await loadSessionRuntimeAccess(supabase, sessionId, user.id);
   const session = getSessionAccessSnapshot(access);
   perf.step('session_loaded');
 
@@ -82,21 +78,33 @@ export async function GET(request: Request, { params }: RouteContext) {
   const { data: answers } = await supabase
     .schema('public')
     .from('answers')
-    .select(
-      'id, question_id, user_id, selected_option, confidence, is_correct, answered_at',
-    )
+    .select('user_id, selected_option, confidence, is_correct, answered_at')
     .eq('question_id', question.id);
   perf.step('answers_loaded');
+  const answerRows = answers ?? [];
+  const ownAnswer =
+    answerRows.find((answer) => answer.user_id === user.id) ?? null;
   perf.done({
     questionId: question.id,
     questionIndex: clampedIndex,
-    answerCount: answers?.length ?? 0,
+    answerCount: answerRows.length,
   });
 
   return NextResponse.json({
     ok: true,
     question,
-    answers: answers ?? [],
+    distribution: computeAnswerDistribution(
+      answerRows,
+      access?.member_count ?? 1,
+    ),
+    ownAnswer: ownAnswer
+      ? {
+          selected_option: ownAnswer.selected_option,
+          confidence: ownAnswer.confidence,
+          is_correct: ownAnswer.is_correct,
+          answered_at: ownAnswer.answered_at,
+        }
+      : null,
     reviewedQuestionCount: reviewedQuestionCount ?? 0,
   });
 }

--- a/components/session/session-review-runtime.tsx
+++ b/components/session/session-review-runtime.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { BarChart3 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { SessionDashboardBackButton } from '@/components/session/session-dashboard-back-button';
 import { SessionFinishReviewButton } from '@/components/session/session-finish-review-button';
@@ -12,10 +12,7 @@ import type {
 } from '@/lib/demo/confidence';
 import { ANSWER_OPTIONS, type AnswerOption } from '@/lib/types/demo';
 
-type ReviewAnswer = {
-  id: string;
-  question_id?: string;
-  user_id: string;
+type ReviewOwnAnswer = {
   selected_option: string | null;
   confidence: string | null;
   is_correct: boolean | null;
@@ -35,21 +32,30 @@ type ReviewQuestion = {
 
 type ReviewPayload = {
   question: ReviewQuestion;
-  answers: ReviewAnswer[];
+  distribution: ReviewDistribution;
+  ownAnswer: ReviewOwnAnswer | null;
   reviewedQuestionCount: number;
+};
+
+type ReviewDistribution = {
+  A: number;
+  B: number;
+  C: number;
+  D: number;
+  E: number;
+  blank: number;
 };
 
 type SessionReviewRuntimeProps = {
   locale: string;
   sessionId: string;
   sessionTitle: string;
-  userId: string;
   questionGoal: number;
-  memberCount: number;
   initialQuestionIndex: number;
   initialReviewedQuestionCount: number;
   initialQuestion: ReviewQuestion;
-  initialAnswers: ReviewAnswer[];
+  initialDistribution: ReviewDistribution;
+  initialOwnAnswer: ReviewOwnAnswer | null;
   labels: {
     reviewShort: string;
     previous: string;
@@ -68,45 +74,28 @@ type SessionReviewRuntimeProps = {
   };
 };
 
-function getDistribution(
-  answers: Array<{ selected_option: string | null }>,
-  memberCount: number,
+const REVIEW_DISTRIBUTION_OPTIONS: Array<AnswerOption | '?'> = [
+  ...ANSWER_OPTIONS,
+  '?',
+];
+
+function getDistributionCount(
+  distribution: ReviewDistribution,
+  option: AnswerOption | '?',
 ) {
-  const distribution = new Map<string, number>();
-  for (const option of [...ANSWER_OPTIONS, '?']) {
-    distribution.set(option, 0);
-  }
-
-  for (const answer of answers) {
-    const option = (answer.selected_option ?? '?').toUpperCase();
-    const normalizedOption = ANSWER_OPTIONS.includes(option as AnswerOption)
-      ? option
-      : '?';
-    distribution.set(
-      normalizedOption,
-      (distribution.get(normalizedOption) ?? 0) + 1,
-    );
-  }
-
-  const submitted = answers.length;
-  distribution.set(
-    '?',
-    Math.max(distribution.get('?') ?? 0, Math.max(0, memberCount - submitted)),
-  );
-  return distribution;
+  return option === '?' ? distribution.blank : distribution[option];
 }
 
 export function SessionReviewRuntime({
   locale,
   sessionId,
   sessionTitle,
-  userId,
   questionGoal,
-  memberCount,
   initialQuestionIndex,
   initialReviewedQuestionCount,
   initialQuestion,
-  initialAnswers,
+  initialDistribution,
+  initialOwnAnswer,
   labels,
 }: SessionReviewRuntimeProps) {
   const [currentIndex, setCurrentIndex] = useState(initialQuestionIndex);
@@ -116,20 +105,16 @@ export function SessionReviewRuntime({
   const [cache, setCache] = useState<Record<number, ReviewPayload>>({
     [initialQuestionIndex]: {
       question: initialQuestion,
-      answers: initialAnswers,
+      distribution: initialDistribution,
+      ownAnswer: initialOwnAnswer,
       reviewedQuestionCount: initialReviewedQuestionCount,
     },
   });
   const [isLoadingQuestion, setIsLoadingQuestion] = useState(false);
   const currentPayload = cache[currentIndex];
   const currentQuestion = currentPayload?.question ?? initialQuestion;
-  const currentAnswers = currentPayload?.answers ?? initialAnswers;
-  const distribution = useMemo(
-    () => getDistribution(currentAnswers, memberCount),
-    [currentAnswers, memberCount],
-  );
-  const myReviewAnswer =
-    currentAnswers.find((answer) => answer.user_id === userId) ?? null;
+  const distribution = currentPayload?.distribution ?? initialDistribution;
+  const myReviewAnswer = currentPayload?.ownAnswer ?? initialOwnAnswer;
   const isLastQuestion = currentIndex >= questionGoal - 1;
   const isFirstQuestion = currentIndex <= 0;
   const canFinish = reviewedQuestionCount >= questionGoal;
@@ -176,7 +161,8 @@ export function SessionReviewRuntime({
           ...current,
           [clampedIndex]: {
             question: payload.question,
-            answers: payload.answers,
+            distribution: payload.distribution,
+            ownAnswer: payload.ownAnswer,
             reviewedQuestionCount: payload.reviewedQuestionCount,
           },
         }));
@@ -302,7 +288,7 @@ export function SessionReviewRuntime({
             </h2>
           </div>
           <div className="mt-2 grid grid-cols-6 gap-1.5 sm:hidden">
-            {[...ANSWER_OPTIONS, '?'].map((option) => (
+            {REVIEW_DISTRIBUTION_OPTIONS.map((option) => (
               <div
                 key={option}
                 className={`inline-flex min-h-7 items-center justify-center rounded-[7px] border px-1 text-center text-[10px] font-semibold ${
@@ -311,12 +297,12 @@ export function SessionReviewRuntime({
                     : 'border-white/[0.08] bg-[#121b2e] text-slate-400'
                 }`}
               >
-                {option}-{distribution.get(option) ?? 0}
+                {option}-{getDistributionCount(distribution, option)}
               </div>
             ))}
           </div>
           <div className="mt-8 hidden grid-cols-3 gap-x-2 gap-y-4 min-[420px]:grid-cols-6 sm:grid">
-            {[...ANSWER_OPTIONS, '?'].map((option) => (
+            {REVIEW_DISTRIBUTION_OPTIONS.map((option) => (
               <div
                 key={option}
                 className="flex w-full flex-col items-center gap-1 text-center"
@@ -332,7 +318,7 @@ export function SessionReviewRuntime({
                   {currentQuestion.correct_option === option ? ' *' : ''}
                 </span>
                 <span className="text-xs font-bold text-slate-600">
-                  {distribution.get(option) ?? 0}
+                  {getDistributionCount(distribution, option)}
                 </span>
               </div>
             ))}

--- a/lib/demo/data.ts
+++ b/lib/demo/data.ts
@@ -1538,14 +1538,17 @@ export const getSessionPageData = cache(
           correct_option?: string | null;
         }>,
         currentQuestion: null,
-        currentQuestionAnswers: [] as Array<{
-          id: string;
-          user_id: string;
+        currentQuestionSubmittedCount: 0,
+        currentUserAnswer: null as {
           selected_option: string | null;
           confidence: string | null;
           is_correct: boolean | null;
           answered_at: string | null;
-        }>,
+        } | null,
+        currentQuestionDistribution: computeAnswerDistribution(
+          [],
+          members.length,
+        ),
         allAnswers: [] as Array<{
           id: string;
           question_id: string;
@@ -1668,11 +1671,14 @@ export const getSessionPageData = cache(
               .schema('public')
               .from('answers')
               .select(
-                'id, question_id, user_id, selected_option, confidence, is_correct, answered_at',
+                'user_id, selected_option, confidence, is_correct, answered_at',
               )
               .eq('question_id', currentReviewQuestion.id)
           ).data ?? [])
         : [];
+      const currentUserAnswer =
+        currentQuestionAnswers.find((answer) => answer.user_id === user.id) ??
+        null;
 
       return {
         session,
@@ -1685,7 +1691,19 @@ export const getSessionPageData = cache(
         questionGoal: session.question_goal ?? 10,
         questions: currentReviewQuestion ? [currentReviewQuestion] : [],
         currentQuestion: currentReviewQuestion,
-        currentQuestionAnswers,
+        currentQuestionSubmittedCount: currentQuestionAnswers.length,
+        currentUserAnswer: currentUserAnswer
+          ? {
+              selected_option: currentUserAnswer.selected_option,
+              confidence: currentUserAnswer.confidence,
+              is_correct: currentUserAnswer.is_correct,
+              answered_at: currentUserAnswer.answered_at,
+            }
+          : null,
+        currentQuestionDistribution: computeAnswerDistribution(
+          currentQuestionAnswers,
+          members.length,
+        ),
         allAnswers: [] as Array<{
           id: string;
           question_id: string;
@@ -1739,12 +1757,11 @@ export const getSessionPageData = cache(
             .schema('public')
             .from('answers')
             .select(
-              'id, user_id, selected_option, confidence, is_correct, answered_at',
+              'user_id, selected_option, confidence, is_correct, answered_at',
             )
             .eq('question_id', currentQuestion.id)
         : Promise.resolve({
             data: [] as Array<{
-              id: string;
               user_id: string;
               selected_option: string | null;
               confidence: string | null;
@@ -1767,7 +1784,20 @@ export const getSessionPageData = cache(
         Math.max((currentQuestion?.order_index ?? 0) + 1, 10),
       questions: currentQuestion ? [currentQuestion] : [],
       currentQuestion,
-      currentQuestionAnswers: questionAnswersResult.data ?? [],
+      currentQuestionSubmittedCount: questionAnswersResult.data?.length ?? 0,
+      currentUserAnswer:
+        questionAnswersResult.data
+          ?.filter((answer) => answer.user_id === user.id)
+          .map((answer) => ({
+            selected_option: answer.selected_option,
+            confidence: answer.confidence,
+            is_correct: answer.is_correct,
+            answered_at: answer.answered_at,
+          }))[0] ?? null,
+      currentQuestionDistribution: computeAnswerDistribution(
+        questionAnswersResult.data ?? [],
+        members.length,
+      ),
       allAnswers: [] as Array<{
         id: string;
         question_id: string;


### PR DESCRIPTION


## Summary
- Stops sending raw participant answer rows to the review client.
- Sends only aggregate answer distribution plus the current user's own answer.
- Preserves review UI behavior while reducing exposed sensitive data.


