### PR TITLE
Make reviewed questions read-only during active review navigation

### DIFF
--- a/app/[locale]/sessions/[sessionId]/actions.ts
+++ b/app/[locale]/sessions/[sessionId]/actions.ts
@@ -485,11 +485,11 @@ export async function saveReviewAnswerAction(formData: FormData) {
   const { data: question } = await supabase
     .schema('public')
     .from('questions')
-    .select('id, session_id')
+    .select('id, session_id, correct_option')
     .eq('id', questionId)
     .maybeSingle();
 
-  if (!question || question.session_id !== sessionId) {
+  if (!question) {
     redirect(
       withFeedback(
         `/${locale}/sessions/${sessionId}?stage=review&q=${questionIndex}`,
@@ -499,11 +499,43 @@ export async function saveReviewAnswerAction(formData: FormData) {
     );
   }
 
-  await supabase
+  if (question.correct_option) {
+    const targetQuestionIndex =
+      advanceAfterSave && Number.isInteger(nextQuestionIndex)
+        ? Math.max(0, Math.min(nextQuestionIndex, session.question_goal - 1))
+        : questionIndex;
+    const feedback =
+      question.correct_option.toUpperCase() === correctOption
+        ? { tone: 'success' as const, message: t('reviewSaved') }
+        : { tone: 'error' as const, message: t('reviewQuestionLocked') };
+
+    redirect(
+      withFeedback(
+        `/${locale}/sessions/${sessionId}?stage=review&q=${targetQuestionIndex}`,
+        feedback.tone,
+        feedback.message,
+      ),
+    );
+  }
+
+  const { data: updatedQuestion } = await supabase
     .schema('public')
     .from('questions')
     .update({ correct_option: correctOption, phase: 'review' })
-    .eq('id', questionId);
+    .eq('id', questionId)
+    .is('correct_option', null)
+    .select('id')
+    .maybeSingle();
+
+  if (!updatedQuestion?.id) {
+    redirect(
+      withFeedback(
+        `/${locale}/sessions/${sessionId}?stage=review&q=${questionIndex}`,
+        'error',
+        t('reviewQuestionLocked'),
+      ),
+    );
+  }
 
   const { data: answers } = await supabase
     .schema('public')
@@ -1008,11 +1040,11 @@ export async function revealAnswerAction(formData: FormData) {
   const { data: question } = await supabase
     .schema('public')
     .from('questions')
-    .select('session_id, asked_by')
+    .select('session_id, asked_by, correct_option')
     .eq('id', questionId)
     .maybeSingle();
 
-  if (!question) {
+  if (!question || question.session_id !== sessionId) {
     redirect(
       withFeedback(
         `/${locale}/sessions/${sessionId}`,
@@ -1086,14 +1118,41 @@ export async function revealAnswerAction(formData: FormData) {
     );
   }
 
-  await supabase
+  if (safeQuestion.correct_option) {
+    redirect(
+      withFeedback(
+        `/${locale}/sessions/${sessionId}`,
+        safeQuestion.correct_option.toUpperCase() === correctOption
+          ? 'success'
+          : 'error',
+        safeQuestion.correct_option.toUpperCase() === correctOption
+          ? t('answerRevealed')
+          : t('reviewQuestionLocked'),
+      ),
+    );
+  }
+
+  const { data: updatedQuestion } = await supabase
     .schema('public')
     .from('questions')
     .update({
       correct_option: correctOption,
       phase: 'review',
     })
-    .eq('id', questionId);
+    .eq('id', questionId)
+    .is('correct_option', null)
+    .select('id')
+    .maybeSingle();
+
+  if (!updatedQuestion?.id) {
+    redirect(
+      withFeedback(
+        `/${locale}/sessions/${sessionId}`,
+        'error',
+        t('reviewQuestionLocked'),
+      ),
+    );
+  }
 
   const { data: answers } = await supabase
     .schema('public')

--- a/app/[locale]/sessions/[sessionId]/page.tsx
+++ b/app/[locale]/sessions/[sessionId]/page.tsx
@@ -227,6 +227,7 @@ export default async function SessionPage({
             saveAndNext: t('saveAndNextReview'),
             updateAndNext: t('updateAndNextReview'),
             savePending: t('saveReviewPending'),
+            reviewLocked: t('reviewLocked'),
             reviewStatus: {
               clearMastery: t('reviewStatus.clearMastery'),
               overconfidence: t('reviewStatus.overconfidence'),

--- a/app/api/sessions/[sessionId]/review-answer/route.ts
+++ b/app/api/sessions/[sessionId]/review-answer/route.ts
@@ -131,20 +131,64 @@ export async function POST(request: Request, { params }: RouteContext) {
   }
   perf.step('session_validated');
 
+  const { data: question } = await supabase
+    .schema('public')
+    .from('questions')
+    .select('id, correct_option')
+    .eq('id', questionId)
+    .eq('session_id', sessionId)
+    .maybeSingle();
+  perf.step('question_loaded');
+
+  if (!question?.id) {
+    return NextResponse.json(
+      { ok: false, message: await getFeedback('notAuthorized') },
+      { status: 403 },
+    );
+  }
+
+  if (question.correct_option) {
+    if (question.correct_option.toUpperCase() === correctOption) {
+      const targetQuestionIndex =
+        advanceAfterSave && Number.isInteger(nextQuestionIndex)
+          ? Math.max(
+              0,
+              Math.min(
+                nextQuestionIndex,
+                Math.max(session.question_goal - 1, 0),
+              ),
+            )
+          : questionIndex;
+
+      return NextResponse.json({
+        ok: true,
+        redirectTo: `/${locale}/sessions/${sessionId}?stage=review&q=${targetQuestionIndex}`,
+        correctOption,
+        targetQuestionIndex,
+      });
+    }
+
+    return NextResponse.json(
+      { ok: false, message: await getFeedback('reviewQuestionLocked') },
+      { status: 409 },
+    );
+  }
+
   const { data: updatedQuestion } = await supabase
     .schema('public')
     .from('questions')
     .update({ correct_option: correctOption, phase: 'review' })
     .eq('id', questionId)
     .eq('session_id', sessionId)
+    .is('correct_option', null)
     .select('id')
     .maybeSingle();
   perf.step('question_updated');
 
   if (!updatedQuestion?.id) {
     return NextResponse.json(
-      { ok: false, message: await getFeedback('notAuthorized') },
-      { status: 403 },
+      { ok: false, message: await getFeedback('reviewQuestionLocked') },
+      { status: 409 },
     );
   }
 

--- a/components/session/session-flow-client.tsx
+++ b/components/session/session-flow-client.tsx
@@ -937,6 +937,7 @@ export function ReviewAnswerForm({
     saveAndNext: string;
     updateAndNext: string;
     savePending: string;
+    reviewLocked: string;
     reviewStatus: Record<CertaintyCorrectnessStatus, string>;
   };
 }) {
@@ -950,8 +951,11 @@ export function ReviewAnswerForm({
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
   const [submissionError, setSubmissionError] = useState<string | null>(null);
   const isPending = saveStatus === 'saving';
+  const isReviewed = Boolean(savedCorrectOption);
   const canSubmit =
-    Boolean(correctOption) && correctOption !== savedCorrectOption;
+    !isReviewed &&
+    Boolean(correctOption) &&
+    correctOption !== savedCorrectOption;
   const hasCorrectOption = Boolean(correctOption);
   const normalizedParticipantAnswer = participantAnswer?.toUpperCase() ?? '?';
   const isCorrect = hasCorrectOption
@@ -1003,7 +1007,7 @@ export function ReviewAnswerForm({
       }
 
       const key = event.key.toUpperCase();
-      if (ANSWER_OPTIONS.includes(key as AnswerOption)) {
+      if (!isReviewed && ANSWER_OPTIONS.includes(key as AnswerOption)) {
         event.preventDefault();
         setCorrectOption(key as AnswerOption);
       }
@@ -1011,7 +1015,7 @@ export function ReviewAnswerForm({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, []);
+  }, [isReviewed]);
 
   async function saveReviewAnswer() {
     if (!canSubmit || isPending) {
@@ -1089,14 +1093,16 @@ export function ReviewAnswerForm({
             key={option}
             type="button"
             onClick={() => {
-              if (option !== '?') setCorrectOption(option as AnswerOption);
+              if (!isReviewed && option !== '?') {
+                setCorrectOption(option as AnswerOption);
+              }
             }}
             className={`h-9 w-full rounded-[7px] border text-sm font-extrabold transition sm:h-11 sm:text-base ${
               correctOption === option
                 ? 'border-brand bg-brand text-white'
-                : 'hover:border-brand/50 border-white/[0.08] bg-[#202b3e] text-slate-300'
+                : 'hover:border-brand/50 border-white/[0.08] bg-[#202b3e] text-slate-300 disabled:hover:border-white/[0.08]'
             }`}
-            disabled={false}
+            disabled={isReviewed || isPending}
           >
             {option}
           </button>
@@ -1122,35 +1128,35 @@ export function ReviewAnswerForm({
           </div>
         </section>
       ) : null}
-      <button
-        type="button"
-        className="button-primary disabled:bg-brand/40 relative h-9 w-full rounded-[7px] py-2 text-sm disabled:cursor-not-allowed disabled:text-white/60 disabled:opacity-70 sm:h-10"
-        disabled={!canSubmit || isPending}
-        onClick={() => {
-          void saveReviewAnswer();
-        }}
-        aria-disabled={!canSubmit || isPending}
-        aria-busy={isPending}
-      >
-        <span className={isPending ? 'text-transparent' : ''}>
-          {isLastQuestion
-            ? savedCorrectOption
-              ? labels.update
-              : labels.save
-            : savedCorrectOption
-              ? labels.updateAndNext
-              : labels.saveAndNext}
-        </span>
-        {isPending ? (
-          <span className="absolute inset-0 inline-flex items-center justify-center gap-2">
-            <span
-              className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
-              aria-hidden="true"
-            />
-            {labels.savePending}
+      {isReviewed ? (
+        <p className="text-center text-xs font-bold uppercase tracking-[0.14em] text-slate-500">
+          {labels.reviewLocked}
+        </p>
+      ) : (
+        <button
+          type="button"
+          className="button-primary disabled:bg-brand/40 relative h-9 w-full rounded-[7px] py-2 text-sm disabled:cursor-not-allowed disabled:text-white/60 disabled:opacity-70 sm:h-10"
+          disabled={!canSubmit || isPending}
+          onClick={() => {
+            void saveReviewAnswer();
+          }}
+          aria-disabled={!canSubmit || isPending}
+          aria-busy={isPending}
+        >
+          <span className={isPending ? 'text-transparent' : ''}>
+            {isLastQuestion ? labels.save : labels.saveAndNext}
           </span>
-        ) : null}
-      </button>
+          {isPending ? (
+            <span className="absolute inset-0 inline-flex items-center justify-center gap-2">
+              <span
+                className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+                aria-hidden="true"
+              />
+              {labels.savePending}
+            </span>
+          ) : null}
+        </button>
+      )}
       {saveStatus === 'saved' ? (
         <p className="text-center text-xs font-bold uppercase tracking-[0.14em] text-brand">
           {labels.save}

--- a/components/session/session-review-runtime.tsx
+++ b/components/session/session-review-runtime.tsx
@@ -64,6 +64,7 @@ type SessionReviewRuntimeProps = {
     saveAndNext: string;
     updateAndNext: string;
     savePending: string;
+    reviewLocked: string;
     reviewStatus: Record<CertaintyCorrectnessStatus, string>;
   };
 };
@@ -360,6 +361,7 @@ export function SessionReviewRuntime({
                 saveAndNext: labels.saveAndNext,
                 updateAndNext: labels.updateAndNext,
                 savePending: labels.savePending,
+                reviewLocked: labels.reviewLocked,
                 reviewStatus: labels.reviewStatus,
               }}
             />

--- a/messages/en.json
+++ b/messages/en.json
@@ -615,6 +615,7 @@
     "saveAndNextReview": "Save and next",
     "updateAndNextReview": "Update and next",
     "saveReviewPending": "Saving review...",
+    "reviewLocked": "Reviewed question locked",
     "stabilityUnstable": "Unstable",
     "stabilityAlmostSolid": "Almost solid",
     "reviewStatus": {
@@ -967,6 +968,7 @@
     "passwordTooShort": "Password must contain at least 8 characters.",
     "notAuthorized": "You do not have access to this resource.",
     "deleteSessionNotAuthorized": "Only the current session captain, the session creator, or the group founder can delete this session.",
+    "reviewQuestionLocked": "This reviewed question can no longer be changed.",
     "groupFull": "This group is already full.",
     "invalidCode": "The invite code is invalid.",
     "invalidSessionCode": "The session code is invalid.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -615,6 +615,7 @@
                     "saveAndNextReview":  "Sauvegarder et suivante",
                     "updateAndNextReview":  "Mettre à jour et suivante",
                     "saveReviewPending":  "Sauvegarde de la révision...",
+                    "reviewLocked":  "Question révisée verrouillée",
                     "stabilityUnstable":  "Instable",
                     "stabilityAlmostSolid":  "Presque solide",
                     "reviewStatus":  {
@@ -967,6 +968,7 @@
                      "passwordTooShort":  "Le mot de passe doit contenir au moins 8 caractères.",
                      "notAuthorized":  "Tu n\u0027as pas accès à cette ressource.",
                      "deleteSessionNotAuthorized":  "Seuls le capitaine actuel de la session, le créateur de la session ou le fondateur du groupe peuvent supprimer cette session.",
+                     "reviewQuestionLocked":  "Cette question déjà révisée ne peut plus être modifiée.",
                      "groupFull":  "Ce groupe est déjà complet.",
                      "invalidCode":  "Le code d\u0027invitation est invalide.",
                      "invalidSessionCode":  "Le code de session est invalide.",


### PR DESCRIPTION


## Summary
- Prevents overwriting a reviewed question's correct answer during the review flow.
- Returns a clear validation error when a reviewed question is edited again.
- Keeps unrevealed/current review questions editable until saved.
- Renders reviewed questions as read-only in the review UI.

## Failed UAT Cases
- REV-4.13


