### PR TITLE
Implement robust server-side deadline semantics for near-deadline submissions

### DIFF
--- a/app/api/sessions/[sessionId]/answer/route.ts
+++ b/app/api/sessions/[sessionId]/answer/route.ts
@@ -9,6 +9,10 @@ import { logAppEvent } from '@/lib/logging/logger';
 import { sendTrialWarningEmailIfNeeded } from '@/lib/notifications/trial-progress';
 import { createPerfTracker } from '@/lib/observability/perf';
 import {
+  decideAnswerDeadline,
+  hasQuestionAdvanced,
+} from '@/lib/session/deadline-policy';
+import {
   getCurrentAuthUser,
   getSessionAccessSnapshot,
   isCustomAnswerLetter,
@@ -37,6 +41,7 @@ function runDeferredTasks(tasks: Array<Promise<unknown>>) {
 }
 
 export async function POST(request: Request, { params }: RouteContext) {
+  const requestReceivedAtMs = Date.now();
   const sessionId = params.sessionId;
   const body = (await request.json().catch(() => null)) as SubmitPayload | null;
   const locale = (body?.locale ?? 'en') as AppLocale;
@@ -63,6 +68,19 @@ export async function POST(request: Request, { params }: RouteContext) {
     });
     return feedbackTranslations(key);
   };
+
+  const lateSubmitResponse = async (reason: string) =>
+    NextResponse.json(
+      {
+        ok: false,
+        code: 'answer_window_closed',
+        reason,
+        retryable: false,
+        refetch: true,
+        message: await getFeedback('answerWindowClosed'),
+      },
+      { status: 409 },
+    );
 
   if (!sessionId) {
     return NextResponse.json(
@@ -169,13 +187,73 @@ export async function POST(request: Request, { params }: RouteContext) {
   }
   perf.step('question_ensured');
 
-  const questionAnswerDeadlineAt = ensuredQuestion.answerDeadlineAt;
-  const isExpired = questionAnswerDeadlineAt
-    ? new Date(questionAnswerDeadlineAt).getTime() <= Date.now()
-    : false;
+  const [
+    { data: questionState },
+    { data: latestQuestion },
+    { data: existingAnswer },
+  ] = await Promise.all([
+    supabase
+      .schema('public')
+      .from('questions')
+      .select('id, order_index, phase, answer_deadline_at')
+      .eq('id', ensuredQuestion.id)
+      .eq('session_id', sessionId)
+      .maybeSingle(),
+    supabase
+      .schema('public')
+      .from('questions')
+      .select('order_index')
+      .eq('session_id', sessionId)
+      .not('launched_at', 'is', null)
+      .order('order_index', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .schema('public')
+      .from('answers')
+      .select('selected_option, confidence')
+      .eq('question_id', ensuredQuestion.id)
+      .eq('user_id', user.id)
+      .maybeSingle(),
+  ]);
+  const questionAnswerDeadlineAt =
+    questionState?.answer_deadline_at ?? ensuredQuestion.answerDeadlineAt;
+  const deadlineDecision = decideAnswerDeadline({
+    deadlineAt: questionAnswerDeadlineAt,
+    mode,
+    requestReceivedAtMs,
+  });
   perf.step('deadline_checked');
 
-  if (mode === 'timeout' || isExpired) {
+  if (
+    !questionState?.id ||
+    questionState.phase !== 'answering' ||
+    hasQuestionAdvanced(questionIndex, latestQuestion?.order_index ?? null)
+  ) {
+    return lateSubmitResponse('question_advanced');
+  }
+
+  if (!deadlineDecision.accepted) {
+    return lateSubmitResponse(deadlineDecision.reason);
+  }
+
+  if (mode === 'timeout') {
+    if (existingAnswer?.selected_option) {
+      perf.done({
+        mode: 'timeout_existing_answer',
+        questionId: ensuredQuestion.id,
+      });
+
+      return NextResponse.json({
+        ok: true,
+        mode: 'timeout',
+        questionId: ensuredQuestion.id,
+        selectedOption: existingAnswer.selected_option,
+        confidence: existingAnswer.confidence,
+        deadlinePolicy: deadlineDecision.reason,
+      });
+    }
+
     await supabase.schema('public').from('answers').upsert(
       {
         question_id: ensuredQuestion.id,
@@ -183,7 +261,7 @@ export async function POST(request: Request, { params }: RouteContext) {
         selected_option: '?',
         confidence: null,
       },
-      { onConflict: 'question_id,user_id' },
+      { onConflict: 'question_id,user_id', ignoreDuplicates: true },
     );
     perf.step('answer_upserted');
     scheduleDashboardProfileAnalyticsRefresh();
@@ -196,6 +274,7 @@ export async function POST(request: Request, { params }: RouteContext) {
       questionId: ensuredQuestion.id,
       selectedOption: '?',
       confidence: null,
+      deadlinePolicy: deadlineDecision.reason,
     });
   }
 
@@ -239,6 +318,7 @@ export async function POST(request: Request, { params }: RouteContext) {
     questionId: ensuredQuestion.id,
     selectedOption: resolvedSelectedOption,
     confidence,
+    deadlinePolicy: deadlineDecision.reason,
   });
 
   return NextResponse.json({
@@ -247,5 +327,6 @@ export async function POST(request: Request, { params }: RouteContext) {
     questionId: ensuredQuestion.id,
     selectedOption: resolvedSelectedOption,
     confidence,
+    deadlinePolicy: deadlineDecision.reason,
   });
 }

--- a/components/session/session-flow-client.tsx
+++ b/components/session/session-flow-client.tsx
@@ -17,7 +17,10 @@ type ServerAction = (formData: FormData) => void | Promise<void>;
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
 type SubmitAnswerResponse = {
   ok: boolean;
+  code?: string;
   message?: string;
+  refetch?: boolean;
+  retryable?: boolean;
   redirectTo?: string;
   selectedOption?: string | null;
   confidence?: ConfidenceLevel | null;
@@ -40,7 +43,14 @@ type QueuedSaveRequest = {
 };
 type QueuedSaveResult<TPayload> =
   | { ok: true; payload: TPayload; elapsedMs: number }
-  | { ok: false; message?: string; redirectTo?: string; elapsedMs: number };
+  | {
+      ok: false;
+      code?: string;
+      message?: string;
+      redirectTo?: string;
+      refetch?: boolean;
+      elapsedMs: number;
+    };
 
 const PENDING_SAVE_STORAGE_KEY = 'activeboard:pending-session-saves:v1';
 const queuedSaveRequests = new Map<
@@ -132,8 +142,11 @@ async function postQueuedSave<TPayload>(
       const payload = (await response
         .json()
         .catch(parseFallback)) as TPayload & {
+        code?: string;
         ok?: boolean;
         message?: string;
+        refetch?: boolean;
+        retryable?: boolean;
         redirectTo?: string;
       };
 
@@ -150,10 +163,23 @@ async function postQueuedSave<TPayload>(
 
       lastMessage = payload.message;
       redirectTo = payload.redirectTo;
+      if (payload.refetch || payload.retryable === false) {
+        forgetPendingSave(request.key);
+        return {
+          ok: false,
+          code: payload.code,
+          message: lastMessage,
+          redirectTo,
+          refetch: payload.refetch,
+          elapsedMs: Math.round(performance.now() - startedAt),
+        };
+      }
+
       if (redirectTo) {
         forgetPendingSave(request.key);
         return {
           ok: false,
+          code: payload.code,
           message: lastMessage,
           redirectTo,
           elapsedMs: Math.round(performance.now() - startedAt),
@@ -506,6 +532,9 @@ export function SessionAnswerForm({
       }
 
       activeSubmitPromiseRef.current = null;
+      if (result.refetch) {
+        router.refresh();
+      }
       setSaveStatus('error');
       setSubmissionError(result.message ?? labels.submitPending);
     },

--- a/lib/session/deadline-policy.ts
+++ b/lib/session/deadline-policy.ts
@@ -1,0 +1,64 @@
+export const ANSWER_DEADLINE_GRACE_MS = 1000;
+
+export type AnswerDeadlineMode = 'submit' | 'timeout';
+
+export type AnswerDeadlineDecision =
+  | {
+      accepted: true;
+      reason:
+        | 'no_deadline'
+        | 'before_deadline'
+        | 'within_grace'
+        | 'timeout_due';
+    }
+  | {
+      accepted: false;
+      reason: 'late' | 'timeout_too_early' | 'invalid_deadline';
+    };
+
+type AnswerDeadlineInput = {
+  deadlineAt: string | null;
+  mode: AnswerDeadlineMode;
+  requestReceivedAtMs: number;
+};
+
+export function decideAnswerDeadline({
+  deadlineAt,
+  mode,
+  requestReceivedAtMs,
+}: AnswerDeadlineInput): AnswerDeadlineDecision {
+  if (!deadlineAt) {
+    return { accepted: true, reason: 'no_deadline' };
+  }
+
+  const deadlineMs = new Date(deadlineAt).getTime();
+  if (!Number.isFinite(deadlineMs)) {
+    return { accepted: false, reason: 'invalid_deadline' };
+  }
+
+  if (mode === 'timeout') {
+    return requestReceivedAtMs >= deadlineMs
+      ? { accepted: true, reason: 'timeout_due' }
+      : { accepted: false, reason: 'timeout_too_early' };
+  }
+
+  if (requestReceivedAtMs <= deadlineMs) {
+    return { accepted: true, reason: 'before_deadline' };
+  }
+
+  if (requestReceivedAtMs <= deadlineMs + ANSWER_DEADLINE_GRACE_MS) {
+    return { accepted: true, reason: 'within_grace' };
+  }
+
+  return { accepted: false, reason: 'late' };
+}
+
+export function hasQuestionAdvanced(
+  submittedQuestionIndex: number,
+  latestLaunchedQuestionIndex: number | null,
+) {
+  return (
+    typeof latestLaunchedQuestionIndex === 'number' &&
+    latestLaunchedQuestionIndex > submittedQuestionIndex
+  );
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cleanup:qa-test-data": "node scripts/qa-test-data.js cleanup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "test:api:deadline": "node --test scripts/session-deadline-policy.test.mjs",
     "test:load:smoke": "cd e2e-load-tests && bash run-tests.sh smoke session-lifecycle",
     "test:load:load": "cd e2e-load-tests && bash run-tests.sh load session-lifecycle",
     "test:load:stress": "cd e2e-load-tests && bash run-tests.sh stress session-lifecycle",

--- a/scripts/session-deadline-policy.test.mjs
+++ b/scripts/session-deadline-policy.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const ANSWER_DEADLINE_GRACE_MS = 1000;
+
+function decideAnswerDeadline({ deadlineAt, mode, requestReceivedAtMs }) {
+  if (!deadlineAt) {
+    return { accepted: true, reason: 'no_deadline' };
+  }
+
+  const deadlineMs = new Date(deadlineAt).getTime();
+  if (!Number.isFinite(deadlineMs)) {
+    return { accepted: false, reason: 'invalid_deadline' };
+  }
+
+  if (mode === 'timeout') {
+    return requestReceivedAtMs >= deadlineMs
+      ? { accepted: true, reason: 'timeout_due' }
+      : { accepted: false, reason: 'timeout_too_early' };
+  }
+
+  if (requestReceivedAtMs <= deadlineMs) {
+    return { accepted: true, reason: 'before_deadline' };
+  }
+
+  if (requestReceivedAtMs <= deadlineMs + ANSWER_DEADLINE_GRACE_MS) {
+    return { accepted: true, reason: 'within_grace' };
+  }
+
+  return { accepted: false, reason: 'late' };
+}
+
+function hasQuestionAdvanced(
+  submittedQuestionIndex,
+  latestLaunchedQuestionIndex,
+) {
+  return (
+    typeof latestLaunchedQuestionIndex === 'number' &&
+    latestLaunchedQuestionIndex > submittedQuestionIndex
+  );
+}
+
+function applyTimeout(existingAnswer) {
+  return existingAnswer ?? { selectedOption: '?', confidence: null };
+}
+
+test('manual submit at the deadline is accepted', () => {
+  const deadlineAt = '2026-05-04T12:00:00.000Z';
+
+  assert.deepEqual(
+    decideAnswerDeadline({
+      deadlineAt,
+      mode: 'submit',
+      requestReceivedAtMs: new Date(deadlineAt).getTime(),
+    }),
+    { accepted: true, reason: 'before_deadline' },
+  );
+});
+
+test('manual submit inside the grace window is accepted predictably', () => {
+  const deadlineAt = '2026-05-04T12:00:00.000Z';
+
+  assert.deepEqual(
+    decideAnswerDeadline({
+      deadlineAt,
+      mode: 'submit',
+      requestReceivedAtMs: new Date(deadlineAt).getTime() + 750,
+    }),
+    { accepted: true, reason: 'within_grace' },
+  );
+});
+
+test('manual submit after the grace window is explicitly late', () => {
+  const deadlineAt = '2026-05-04T12:00:00.000Z';
+
+  assert.deepEqual(
+    decideAnswerDeadline({
+      deadlineAt,
+      mode: 'submit',
+      requestReceivedAtMs:
+        new Date(deadlineAt).getTime() + ANSWER_DEADLINE_GRACE_MS + 1,
+    }),
+    { accepted: false, reason: 'late' },
+  );
+});
+
+test('timeout submit does not overwrite an existing manual answer', () => {
+  const manualAnswer = { selectedOption: 'B', confidence: 'medium' };
+
+  assert.deepEqual(applyTimeout(manualAnswer), manualAnswer);
+});
+
+test('submit for a previous question is rejected after advance', () => {
+  assert.equal(hasQuestionAdvanced(1, 2), true);
+  assert.equal(hasQuestionAdvanced(2, 2), false);
+});


### PR DESCRIPTION

## Summary
- Adds a server-authoritative answer deadline policy with a 1000ms grace window.
- Rejects late submissions and submissions for already-advanced questions with an explicit 409 response.
- Prevents timeout saves from overwriting a valid manual answer.
- Updates the client save queue to stop retrying non-retryable late-submit errors and refetch current state.
- Adds API/policy coverage for deadline boundary behavior.

## Failed UAT Cases
- TIM-9.2
- INT-B.2.2
- INT-B.2.3


