### PR TITLE
Introduce distinct skipped answer state instead of conflating skipped with “?”

### DIFF
--- a/app/[locale]/sessions/[sessionId]/actions.ts
+++ b/app/[locale]/sessions/[sessionId]/actions.ts
@@ -265,7 +265,8 @@ export async function submitSessionStepAction(formData: FormData) {
       {
         question_id: resolvedQuestionId,
         user_id: user.id,
-        selected_option: '?',
+        answer_state: 'skipped',
+        selected_option: null,
         confidence: null,
       },
       { onConflict: 'question_id,user_id' },
@@ -280,6 +281,7 @@ export async function submitSessionStepAction(formData: FormData) {
     {
       question_id: resolvedQuestionId,
       user_id: user.id,
+      answer_state: 'submitted',
       selected_option: resolvedSelectedOption,
       confidence,
     },
@@ -365,7 +367,8 @@ export async function timeoutSessionStepAction(formData: FormData) {
     {
       question_id: resolvedQuestionId,
       user_id: user.id,
-      selected_option: '?',
+      answer_state: 'skipped',
+      selected_option: null,
       confidence: null,
     },
     { onConflict: 'question_id,user_id' },
@@ -509,6 +512,7 @@ export async function saveReviewAnswerAction(formData: FormData) {
     .schema('public')
     .from('answers')
     .select('id, selected_option')
+    .eq('answer_state', 'submitted')
     .eq('question_id', questionId);
 
   await Promise.all(
@@ -964,6 +968,7 @@ export async function submitAnswerAction(formData: FormData) {
     {
       question_id: questionId,
       user_id: user.id,
+      answer_state: 'submitted',
       selected_option: resolvedSelectedOption,
       confidence,
     },
@@ -1099,6 +1104,7 @@ export async function revealAnswerAction(formData: FormData) {
     .schema('public')
     .from('answers')
     .select('id, selected_option')
+    .eq('answer_state', 'submitted')
     .eq('question_id', questionId);
 
   await Promise.all(

--- a/app/[locale]/sessions/[sessionId]/page.tsx
+++ b/app/[locale]/sessions/[sessionId]/page.tsx
@@ -219,6 +219,7 @@ export default async function SessionPage({
             next: t('next'),
             questionUpper: t('questionUpper'),
             distribution: t('distribution'),
+            skippedAnswer: t('skippedAnswer'),
             finishSession: t('finishSession'),
             finishSessionPending: t('finishSessionPending'),
             correctAnswer: t('correctAnswer'),

--- a/app/api/sessions/[sessionId]/answer/route.ts
+++ b/app/api/sessions/[sessionId]/answer/route.ts
@@ -180,7 +180,8 @@ export async function POST(request: Request, { params }: RouteContext) {
       {
         question_id: ensuredQuestion.id,
         user_id: user.id,
-        selected_option: '?',
+        answer_state: 'skipped',
+        selected_option: null,
         confidence: null,
       },
       { onConflict: 'question_id,user_id' },
@@ -194,8 +195,9 @@ export async function POST(request: Request, { params }: RouteContext) {
       ok: true,
       mode: 'timeout',
       questionId: ensuredQuestion.id,
-      selectedOption: '?',
+      selectedOption: null,
       confidence: null,
+      answerState: 'skipped',
     });
   }
 
@@ -205,6 +207,7 @@ export async function POST(request: Request, { params }: RouteContext) {
     {
       question_id: ensuredQuestion.id,
       user_id: user.id,
+      answer_state: 'submitted',
       selected_option: resolvedSelectedOption,
       confidence,
     },
@@ -247,5 +250,6 @@ export async function POST(request: Request, { params }: RouteContext) {
     questionId: ensuredQuestion.id,
     selectedOption: resolvedSelectedOption,
     confidence,
+    answerState: 'submitted',
   });
 }

--- a/app/api/sessions/[sessionId]/review-answer/route.ts
+++ b/app/api/sessions/[sessionId]/review-answer/route.ts
@@ -154,12 +154,14 @@ export async function POST(request: Request, { params }: RouteContext) {
       .from('answers')
       .update({ is_correct: true })
       .eq('question_id', questionId)
+      .eq('answer_state', 'submitted')
       .eq('selected_option', correctOption),
     supabase
       .schema('public')
       .from('answers')
       .update({ is_correct: false })
       .eq('question_id', questionId)
+      .eq('answer_state', 'submitted')
       .neq('selected_option', correctOption),
   ]);
   perf.step('review_updates_saved');

--- a/app/api/sessions/[sessionId]/review-question/route.ts
+++ b/app/api/sessions/[sessionId]/review-question/route.ts
@@ -83,7 +83,7 @@ export async function GET(request: Request, { params }: RouteContext) {
     .schema('public')
     .from('answers')
     .select(
-      'id, question_id, user_id, selected_option, confidence, is_correct, answered_at',
+      'id, question_id, user_id, answer_state, selected_option, confidence, is_correct, answered_at',
     )
     .eq('question_id', question.id);
   perf.step('answers_loaded');

--- a/components/session/session-review-runtime.tsx
+++ b/components/session/session-review-runtime.tsx
@@ -10,12 +10,17 @@ import type {
   CertaintyCorrectnessStatus,
   ConfidenceLevel,
 } from '@/lib/demo/confidence';
-import { ANSWER_OPTIONS, type AnswerOption } from '@/lib/types/demo';
+import {
+  ANSWER_OPTIONS,
+  type AnswerOption,
+  type AnswerState,
+} from '@/lib/types/demo';
 
 type ReviewAnswer = {
   id: string;
   question_id?: string;
   user_id: string;
+  answer_state?: AnswerState | null;
   selected_option: string | null;
   confidence: string | null;
   is_correct: boolean | null;
@@ -56,6 +61,7 @@ type SessionReviewRuntimeProps = {
     next: string;
     questionUpper: string;
     distribution: string;
+    skippedAnswer: string;
     finishSession: string;
     finishSessionPending: string;
     correctAnswer: string;
@@ -69,15 +75,23 @@ type SessionReviewRuntimeProps = {
 };
 
 function getDistribution(
-  answers: Array<{ selected_option: string | null }>,
+  answers: Array<{
+    answer_state?: AnswerState | null;
+    selected_option: string | null;
+  }>,
   memberCount: number,
 ) {
   const distribution = new Map<string, number>();
-  for (const option of [...ANSWER_OPTIONS, '?']) {
+  for (const option of [...ANSWER_OPTIONS, '?', 'skipped']) {
     distribution.set(option, 0);
   }
 
   for (const answer of answers) {
+    if (answer.answer_state === 'skipped') {
+      distribution.set('skipped', (distribution.get('skipped') ?? 0) + 1);
+      continue;
+    }
+
     const option = (answer.selected_option ?? '?').toUpperCase();
     const normalizedOption = ANSWER_OPTIONS.includes(option as AnswerOption)
       ? option
@@ -90,8 +104,8 @@ function getDistribution(
 
   const submitted = answers.length;
   distribution.set(
-    '?',
-    Math.max(distribution.get('?') ?? 0, Math.max(0, memberCount - submitted)),
+    'skipped',
+    (distribution.get('skipped') ?? 0) + Math.max(0, memberCount - submitted),
   );
   return distribution;
 }
@@ -301,8 +315,8 @@ export function SessionReviewRuntime({
               {labels.distribution}
             </h2>
           </div>
-          <div className="mt-2 grid grid-cols-6 gap-1.5 sm:hidden">
-            {[...ANSWER_OPTIONS, '?'].map((option) => (
+          <div className="mt-2 grid grid-cols-4 gap-1.5 min-[420px]:grid-cols-7 sm:hidden">
+            {([...ANSWER_OPTIONS, '?', 'skipped'] as const).map((option) => (
               <div
                 key={option}
                 className={`inline-flex min-h-7 items-center justify-center rounded-[7px] border px-1 text-center text-[10px] font-semibold ${
@@ -311,12 +325,13 @@ export function SessionReviewRuntime({
                     : 'border-white/[0.08] bg-[#121b2e] text-slate-400'
                 }`}
               >
-                {option}-{distribution.get(option) ?? 0}
+                {option === 'skipped' ? labels.skippedAnswer : option}-
+                {distribution.get(option) ?? 0}
               </div>
             ))}
           </div>
-          <div className="mt-8 hidden grid-cols-3 gap-x-2 gap-y-4 min-[420px]:grid-cols-6 sm:grid">
-            {[...ANSWER_OPTIONS, '?'].map((option) => (
+          <div className="mt-8 hidden grid-cols-3 gap-x-2 gap-y-4 min-[420px]:grid-cols-7 sm:grid">
+            {([...ANSWER_OPTIONS, '?', 'skipped'] as const).map((option) => (
               <div
                 key={option}
                 className="flex w-full flex-col items-center gap-1 text-center"
@@ -328,7 +343,7 @@ export function SessionReviewRuntime({
                       : 'text-sm font-bold text-slate-500'
                   }
                 >
-                  {option}
+                  {option === 'skipped' ? labels.skippedAnswer : option}
                   {currentQuestion.correct_option === option ? ' *' : ''}
                 </span>
                 <span className="text-xs font-bold text-slate-600">

--- a/lib/demo/data.ts
+++ b/lib/demo/data.ts
@@ -1201,6 +1201,7 @@ export const getGroupData = cache(async (groupId: string, user: User) => {
           .schema('public')
           .from('answers')
           .select('question_id, user_id')
+          .eq('answer_state', 'submitted')
           .in('question_id', groupQuestionIds)
       : { data: [] as { question_id: string; user_id: string }[] };
 
@@ -1541,6 +1542,7 @@ export const getSessionPageData = cache(
         currentQuestionAnswers: [] as Array<{
           id: string;
           user_id: string;
+          answer_state: 'submitted' | 'skipped';
           selected_option: string | null;
           confidence: string | null;
           is_correct: boolean | null;
@@ -1550,6 +1552,7 @@ export const getSessionPageData = cache(
           id: string;
           question_id: string;
           user_id: string;
+          answer_state: 'submitted' | 'skipped';
           selected_option: string | null;
           confidence: string | null;
           is_correct: boolean | null;
@@ -1668,7 +1671,7 @@ export const getSessionPageData = cache(
               .schema('public')
               .from('answers')
               .select(
-                'id, question_id, user_id, selected_option, confidence, is_correct, answered_at',
+                'id, question_id, user_id, answer_state, selected_option, confidence, is_correct, answered_at',
               )
               .eq('question_id', currentReviewQuestion.id)
           ).data ?? [])
@@ -1690,6 +1693,7 @@ export const getSessionPageData = cache(
           id: string;
           question_id: string;
           user_id: string;
+          answer_state: 'submitted' | 'skipped';
           selected_option: string | null;
           confidence: string | null;
           is_correct: boolean | null;
@@ -1739,13 +1743,14 @@ export const getSessionPageData = cache(
             .schema('public')
             .from('answers')
             .select(
-              'id, user_id, selected_option, confidence, is_correct, answered_at',
+              'id, user_id, answer_state, selected_option, confidence, is_correct, answered_at',
             )
             .eq('question_id', currentQuestion.id)
         : Promise.resolve({
             data: [] as Array<{
               id: string;
               user_id: string;
+              answer_state: 'submitted' | 'skipped';
               selected_option: string | null;
               confidence: string | null;
               is_correct: boolean | null;
@@ -1772,6 +1777,7 @@ export const getSessionPageData = cache(
         id: string;
         question_id: string;
         user_id: string;
+        answer_state: 'submitted' | 'skipped';
         selected_option: string | null;
         confidence: string | null;
         is_correct: boolean | null;
@@ -1847,7 +1853,7 @@ export const getSessionData = cache(async (sessionId: string, user: User) => {
           .schema('public')
           .from('answers')
           .select(
-            'id, user_id, selected_option, confidence, is_correct, answered_at',
+            'id, user_id, answer_state, selected_option, confidence, is_correct, answered_at',
           )
           .eq('question_id', currentQuestion.id)
       ).data ?? [])
@@ -1859,7 +1865,7 @@ export const getSessionData = cache(async (sessionId: string, user: User) => {
             .schema('public')
             .from('answers')
             .select(
-              'id, question_id, user_id, selected_option, confidence, is_correct, answered_at',
+              'id, question_id, user_id, answer_state, selected_option, confidence, is_correct, answered_at',
             )
             .in('question_id', questionIds)
         ).data ?? [])
@@ -2013,7 +2019,7 @@ export const getSessionSummaryData = cache(
               .schema('public')
               .from('answers')
               .select(
-                'question_id, user_id, selected_option, confidence, is_correct',
+                'question_id, user_id, answer_state, selected_option, confidence, is_correct',
               )
               .in('question_id', questionIds)
           ).data ?? [])
@@ -2047,7 +2053,12 @@ export const getSessionSummaryData = cache(
         : [];
 
     const memberCount = members?.length ?? 0;
-    const myAnswers = answers.filter((answer) => answer.user_id === user.id);
+    const submittedAnswers = answers.filter(
+      (answer) => answer.answer_state !== 'skipped',
+    );
+    const myAnswers = submittedAnswers.filter(
+      (answer) => answer.user_id === user.id,
+    );
     const correctCount = myAnswers.filter((answer) => answer.is_correct).length;
     const totalQuestions = questions?.length ?? 0;
     const answeredCount = myAnswers.length;
@@ -2073,7 +2084,7 @@ export const getSessionSummaryData = cache(
         : 0;
 
     const breakdown = (questions ?? []).map((question) => {
-      const questionAnswers = answers.filter(
+      const questionAnswers = submittedAnswers.filter(
         (answer) => answer.question_id === question.id,
       );
       const myAnswer =

--- a/lib/demo/distribution.ts
+++ b/lib/demo/distribution.ts
@@ -1,6 +1,9 @@
-import { ANSWER_OPTIONS } from '@/lib/types/demo';
+import { ANSWER_OPTIONS, type AnswerState } from '@/lib/types/demo';
 
-type DistributionInput = Array<{ selected_option: string | null }>;
+type DistributionInput = Array<{
+  answer_state?: AnswerState | null;
+  selected_option: string | null;
+}>;
 
 export function computeAnswerDistribution(
   answers: DistributionInput,
@@ -13,12 +16,21 @@ export function computeAnswerDistribution(
     D: 0,
     E: 0,
     blank: 0,
+    skipped: 0,
   };
 
   for (const answer of answers) {
+    if (answer.answer_state === 'skipped') {
+      counts.skipped++;
+      continue;
+    }
+
     const option = answer.selected_option?.toUpperCase();
 
-    if (option && ANSWER_OPTIONS.includes(option as (typeof ANSWER_OPTIONS)[number])) {
+    if (
+      option &&
+      ANSWER_OPTIONS.includes(option as (typeof ANSWER_OPTIONS)[number])
+    ) {
       counts[option as keyof typeof counts]++;
     } else {
       counts.blank++;
@@ -26,7 +38,7 @@ export function computeAnswerDistribution(
   }
 
   const missing = Math.max(0, participantCount - answers.length);
-  counts.blank += missing;
+  counts.skipped += missing;
 
   return counts;
 }

--- a/lib/groups/server.ts
+++ b/lib/groups/server.ts
@@ -322,6 +322,7 @@ export async function getGroupWeeklyProgress(groupId: string) {
     .schema('public')
     .from('answers')
     .select('question_id')
+    .eq('answer_state', 'submitted')
     .in('question_id', questionIds);
 
   const questionAnswerCounts = new Map<string, number>();

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -1,6 +1,11 @@
 import type { ConfidenceLevel } from '@/lib/demo/confidence';
 import type { AvailabilityGrid } from '@/lib/schedule/availability';
-import type { DimensionOfCare, ErrorType, PhysicianActivity } from '@/lib/types/demo';
+import type {
+  AnswerState,
+  DimensionOfCare,
+  ErrorType,
+  PhysicianActivity,
+} from '@/lib/types/demo';
 
 export type Json =
   | string
@@ -11,6 +16,7 @@ export type Json =
   | Json[];
 
 type AnswersRow = {
+  answer_state: AnswerState;
   answered_at: string;
   confidence: ConfidenceLevel | null;
   id: string;
@@ -21,6 +27,7 @@ type AnswersRow = {
 };
 
 type AnswersInsert = {
+  answer_state?: AnswerState;
   answered_at?: string;
   confidence?: ConfidenceLevel | null;
   id?: string;
@@ -31,6 +38,7 @@ type AnswersInsert = {
 };
 
 type AnswersUpdate = {
+  answer_state?: AnswerState;
   answered_at?: string;
   confidence?: ConfidenceLevel | null;
   id?: string;
@@ -194,7 +202,14 @@ type GroupWeeklySchedulesRow = {
   id: string;
   question_goal: number;
   start_time: string;
-  weekday: 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday' | 'sunday';
+  weekday:
+    | 'monday'
+    | 'tuesday'
+    | 'wednesday'
+    | 'thursday'
+    | 'friday'
+    | 'saturday'
+    | 'sunday';
 };
 
 type GroupWeeklySchedulesInsert = {
@@ -204,7 +219,14 @@ type GroupWeeklySchedulesInsert = {
   id?: string;
   question_goal?: number;
   start_time: string;
-  weekday: 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday' | 'sunday';
+  weekday:
+    | 'monday'
+    | 'tuesday'
+    | 'wednesday'
+    | 'thursday'
+    | 'friday'
+    | 'saturday'
+    | 'sunday';
 };
 
 type GroupWeeklySchedulesUpdate = {
@@ -214,7 +236,14 @@ type GroupWeeklySchedulesUpdate = {
   id?: string;
   question_goal?: number;
   start_time?: string;
-  weekday?: 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday' | 'sunday';
+  weekday?:
+    | 'monday'
+    | 'tuesday'
+    | 'wednesday'
+    | 'thursday'
+    | 'friday'
+    | 'saturday'
+    | 'sunday';
 };
 
 type QuestionsRow = {
@@ -434,7 +463,12 @@ type UsersRow = {
   display_name: string | null;
   email: string;
   exam_type: 'mccqe1' | 'usmle' | 'plab' | 'other' | null;
-  exam_session: 'april_may_2026' | 'august_september_2026' | 'october_2026' | 'planning_ahead' | null;
+  exam_session:
+    | 'april_may_2026'
+    | 'august_september_2026'
+    | 'october_2026'
+    | 'planning_ahead'
+    | null;
   has_valid_payment_method: boolean;
   id: string;
   locale: 'en' | 'fr';
@@ -463,7 +497,12 @@ type UsersInsert = {
   display_name?: string | null;
   email: string;
   exam_type?: 'mccqe1' | 'usmle' | 'plab' | 'other' | null;
-  exam_session?: 'april_may_2026' | 'august_september_2026' | 'october_2026' | 'planning_ahead' | null;
+  exam_session?:
+    | 'april_may_2026'
+    | 'august_september_2026'
+    | 'october_2026'
+    | 'planning_ahead'
+    | null;
   has_valid_payment_method?: boolean;
   id: string;
   locale?: 'en' | 'fr';
@@ -492,7 +531,12 @@ type UsersUpdate = {
   display_name?: string | null;
   email?: string;
   exam_type?: 'mccqe1' | 'usmle' | 'plab' | 'other' | null;
-  exam_session?: 'april_may_2026' | 'august_september_2026' | 'october_2026' | 'planning_ahead' | null;
+  exam_session?:
+    | 'april_may_2026'
+    | 'august_september_2026'
+    | 'october_2026'
+    | 'planning_ahead'
+    | null;
   has_valid_payment_method?: boolean;
   id?: string;
   locale?: 'en' | 'fr';

--- a/lib/types/demo.ts
+++ b/lib/types/demo.ts
@@ -2,15 +2,26 @@ export type Locale = 'en' | 'fr';
 
 export type GroupMembershipKind = 'founder' | 'member';
 
-export type GroupInviteStatus = 'pending' | 'accepted' | 'declined' | 'cancelled';
+export type GroupInviteStatus =
+  | 'pending'
+  | 'accepted'
+  | 'declined'
+  | 'cancelled';
 
-export type SessionStatus = 'scheduled' | 'active' | 'incomplete' | 'completed' | 'cancelled';
+export type SessionStatus =
+  | 'scheduled'
+  | 'active'
+  | 'incomplete'
+  | 'completed'
+  | 'cancelled';
 
 export type QuestionPhase = 'draft' | 'answering' | 'review' | 'closed';
 
 export type AnswerOption = 'A' | 'B' | 'C' | 'D' | 'E';
 
 export const ANSWER_OPTIONS: AnswerOption[] = ['A', 'B', 'C', 'D', 'E'];
+
+export type AnswerState = 'submitted' | 'skipped';
 
 export type PhysicianActivity =
   | 'history_taking'
@@ -62,4 +73,3 @@ export const ERROR_TYPE_OPTIONS: ErrorType[] = [
   'time_pressure',
   'careless_mistake',
 ];
-

--- a/messages/en.json
+++ b/messages/en.json
@@ -610,6 +610,7 @@
     "previous": "Prev",
     "next": "Next",
     "distribution": "Distribution",
+    "skippedAnswer": "Skipped",
     "saveReview": "Save",
     "updateReview": "Update",
     "saveAndNextReview": "Save and next",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -610,6 +610,7 @@
                     "previous":  "Préc",
                     "next":  "Suiv",
                     "distribution":  "Distribution",
+                    "skippedAnswer":  "Ignorée",
                     "saveReview":  "Sauvegarder",
                     "updateReview":  "Mettre à jour",
                     "saveAndNextReview":  "Sauvegarder et suivante",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cleanup:qa-test-data": "node scripts/qa-test-data.js cleanup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "test:api:skipped-answer": "node --test scripts/skipped-answer-state.test.mjs",
     "test:load:smoke": "cd e2e-load-tests && bash run-tests.sh smoke session-lifecycle",
     "test:load:load": "cd e2e-load-tests && bash run-tests.sh load session-lifecycle",
     "test:load:stress": "cd e2e-load-tests && bash run-tests.sh stress session-lifecycle",

--- a/scripts/skipped-answer-state.test.mjs
+++ b/scripts/skipped-answer-state.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const ANSWER_OPTIONS = ['A', 'B', 'C', 'D', 'E'];
+
+function computeAnswerDistribution(answers, participantCount) {
+  const counts = {
+    A: 0,
+    B: 0,
+    C: 0,
+    D: 0,
+    E: 0,
+    blank: 0,
+    skipped: 0,
+  };
+
+  for (const answer of answers) {
+    if (answer.answer_state === 'skipped') {
+      counts.skipped++;
+      continue;
+    }
+
+    const option = answer.selected_option?.toUpperCase();
+    if (option && ANSWER_OPTIONS.includes(option)) {
+      counts[option]++;
+    } else {
+      counts.blank++;
+    }
+  }
+
+  counts.skipped += Math.max(0, participantCount - answers.length);
+  return counts;
+}
+
+function countQuotaAnswers(answers) {
+  return answers.filter((answer) => answer.answer_state !== 'skipped').length;
+}
+
+test('submitted custom unknown answer remains distinct from skipped', () => {
+  const distribution = computeAnswerDistribution(
+    [
+      { answer_state: 'submitted', selected_option: 'G' },
+      { answer_state: 'skipped', selected_option: null },
+    ],
+    2,
+  );
+
+  assert.equal(distribution.blank, 1);
+  assert.equal(distribution.skipped, 1);
+});
+
+test('missing participants are counted as skipped in review distribution', () => {
+  const distribution = computeAnswerDistribution(
+    [{ answer_state: 'submitted', selected_option: 'A' }],
+    3,
+  );
+
+  assert.equal(distribution.A, 1);
+  assert.equal(distribution.skipped, 2);
+});
+
+test('skipped answers are excluded from quota-style counting', () => {
+  assert.equal(
+    countQuotaAnswers([
+      { answer_state: 'submitted' },
+      { answer_state: 'skipped' },
+      { answer_state: 'submitted' },
+    ]),
+    2,
+  );
+});

--- a/supabase/migrations/20260504170000_answer_state_skipped.sql
+++ b/supabase/migrations/20260504170000_answer_state_skipped.sql
@@ -1,0 +1,160 @@
+do $$
+begin
+  if not exists (select 1 from pg_type where typname = 'answer_state') then
+    create type public.answer_state as enum ('submitted', 'skipped');
+  end if;
+end $$;
+
+alter table public.answers
+  add column if not exists answer_state public.answer_state not null default 'submitted';
+
+update public.users u
+set questions_answered = coalesce(source.answer_count, 0)
+from (
+  select user_id, count(*)::integer as answer_count
+  from public.answers
+  where answer_state = 'submitted'
+  group by user_id
+) source
+where source.user_id = u.id;
+
+update public.users
+set questions_answered = 0
+where id not in (
+  select distinct user_id
+  from public.answers
+  where answer_state = 'submitted'
+);
+
+alter table public.answers
+  add constraint answers_skipped_state_shape
+  check (
+    answer_state = 'submitted'
+    or (
+      answer_state = 'skipped'
+      and selected_option is null
+      and confidence is null
+    )
+  ) not valid;
+
+create index if not exists idx_answers_user_id_state_answered_at
+  on public.answers (user_id, answer_state, answered_at);
+
+create or replace function public.sync_user_questions_answered()
+returns trigger
+language plpgsql
+as $$
+begin
+  if tg_op = 'INSERT' then
+    if new.answer_state = 'submitted' then
+      update public.users
+      set questions_answered = questions_answered + 1
+      where id = new.user_id;
+    end if;
+
+    return new;
+  elsif tg_op = 'DELETE' then
+    if old.answer_state = 'submitted' then
+      update public.users
+      set questions_answered = greatest(questions_answered - 1, 0)
+      where id = old.user_id;
+    end if;
+
+    return old;
+  elsif tg_op = 'UPDATE' then
+    if old.user_id is distinct from new.user_id then
+      if old.answer_state = 'submitted' then
+        update public.users
+        set questions_answered = greatest(questions_answered - 1, 0)
+        where id = old.user_id;
+      end if;
+
+      if new.answer_state = 'submitted' then
+        update public.users
+        set questions_answered = questions_answered + 1
+        where id = new.user_id;
+      end if;
+    elsif old.answer_state is distinct from new.answer_state then
+      if old.answer_state = 'submitted' then
+        update public.users
+        set questions_answered = greatest(questions_answered - 1, 0)
+        where id = old.user_id;
+      end if;
+
+      if new.answer_state = 'submitted' then
+        update public.users
+        set questions_answered = questions_answered + 1
+        where id = new.user_id;
+      end if;
+    end if;
+
+    return new;
+  end if;
+
+  return null;
+end;
+$$;
+
+create or replace view public.dashboard_user_session_answer_counts
+with (security_invoker = true) as
+select
+  a.user_id,
+  q.session_id,
+  count(*) filter (where a.answer_state = 'submitted')::bigint as answered_question_count
+from public.answers a
+join public.questions q on q.id = a.question_id
+group by a.user_id, q.session_id;
+
+create or replace view public.dashboard_user_answer_metrics
+with (security_invoker = true) as
+select
+  a.user_id,
+  count(*) filter (where a.answer_state = 'submitted')::bigint as answered_count,
+  count(*) filter (where a.answer_state = 'submitted' and a.is_correct is true)::bigint as correct_count,
+  count(*) filter (where a.answer_state = 'submitted' and a.is_correct is false)::bigint as incorrect_count,
+  avg(
+    case
+      when a.answer_state <> 'submitted' then null
+      when a.confidence = 'low' then 1
+      when a.confidence = 'medium' then 2
+      when a.confidence = 'high' then 3
+      else null
+    end
+  )::numeric as average_confidence_score
+from public.answers a
+group by a.user_id;
+
+create or replace view public.dashboard_user_answer_daily_counts
+with (security_invoker = true) as
+select
+  a.user_id,
+  timezone('utc', a.answered_at)::date as answered_on,
+  count(*) filter (where a.answer_state = 'submitted')::bigint as answer_count
+from public.answers a
+group by a.user_id, timezone('utc', a.answered_at)::date;
+
+drop materialized view if exists public.dashboard_user_session_confidence_breakdown;
+create materialized view public.dashboard_user_session_confidence_breakdown as
+select
+  a.user_id,
+  s.id as session_id,
+  coalesce(nullif(trim(s.name), ''), g.name, 'Session') as session_name,
+  s.scheduled_at,
+  count(*) filter (where a.confidence = 'low')::int as low_count,
+  count(*) filter (where a.confidence = 'medium')::int as medium_count,
+  count(*) filter (where a.confidence = 'high')::int as high_count
+from public.answers a
+join public.questions q on q.id = a.question_id
+join public.sessions s on s.id = q.session_id
+left join public.groups g on g.id = s.group_id
+where a.answer_state = 'submitted'
+  and a.confidence in ('low', 'medium', 'high')
+group by a.user_id, s.id, coalesce(nullif(trim(s.name), ''), g.name, 'Session'), s.scheduled_at;
+
+create unique index if not exists idx_dashboard_user_session_confidence_breakdown_user_session
+  on public.dashboard_user_session_confidence_breakdown (user_id, session_id);
+
+create index if not exists idx_dashboard_user_session_confidence_breakdown_user_scheduled_at
+  on public.dashboard_user_session_confidence_breakdown (user_id, scheduled_at desc);
+
+grant select on public.dashboard_user_session_confidence_breakdown to authenticated;


### PR DESCRIPTION
## Summary
- Adds an explicit `answer_state` data model with `submitted` and `skipped`.
- Writes timeout/absent answers as skipped instead of `selected_option = '?'`.
- Preserves existing custom/unknown answer behavior as submitted answers.
- Updates review distribution to show skipped separately from `?`.
- Excludes skipped answers from quota/dashboard-style submitted answer counts.
- Adds tests for skipped answer semantics.

## Failed UAT Cases
- TIM-9.3


