### PR TITLE
Fix PWA dashboard launch start URL

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "ActiveBoard",
   "short_name": "ActiveBoard",
   "description": "Phone-first collaborative study platform for real-time medical exam prep.",
-  "start_url": "/en",
+  "start_url": "/dashboard",
   "scope": "/",
   "display": "standalone",
   "background_color": "#f8fafc",


### PR DESCRIPTION
## Summary
- Update the PWA manifest `start_url` from `/en` to `/dashboard`.
- Keep ActiveBoard install metadata unchanged: standalone display, name, short name, scope, and icons.
- Rely on the existing locale middleware and dashboard auth guard so launches resolve safely by user state.

## UAT Coverage
Fixes MOB-14.2.




